### PR TITLE
Deployment refactoring:

### DIFF
--- a/src/main/java/org/craftercms/deployer/DeployerApplication.java
+++ b/src/main/java/org/craftercms/deployer/DeployerApplication.java
@@ -68,8 +68,8 @@ public class DeployerApplication extends WebMvcConfigurerAdapter implements Sche
 	private boolean scheduledTargetScanEnabled;
 	@Value("${deployer.main.targets.scan.scheduling.cron}")
 	private String scheduledTargetScanCron;
-	@Value("${deployer.main.scheduling.poolSize}")
-	private int schedulerPoolSize;
+	@Value("${deployer.main.taskScheduler.poolSize}")
+	private int taskSchedulerPoolSize;
 	@Value("${deployer.main.targets.config.templates.location}")
 	private String targetConfigTemplatesLocation;
 	@Value("${deployer.main.targets.config.templates.overrideLocation}")
@@ -125,16 +125,9 @@ public class DeployerApplication extends WebMvcConfigurerAdapter implements Sche
 	@Bean(destroyMethod="shutdown")
 	public TaskScheduler taskScheduler() {
 		ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
-		taskScheduler.setPoolSize(schedulerPoolSize);
+		taskScheduler.setPoolSize(taskSchedulerPoolSize);
 
 		return taskScheduler;
-	}
-
-	@Bean(destroyMethod="shutdown")
-	public AsyncTaskExecutor taskExecutor() {
-		ThreadPoolTaskExecutor taskExecutor = new ThreadPoolTaskExecutor();
-		taskExecutor.setMaxPoolSize(schedulerPoolSize);
-		return taskExecutor;
 	}
 
 	@Bean

--- a/src/main/java/org/craftercms/deployer/api/DeploymentPipeline.java
+++ b/src/main/java/org/craftercms/deployer/api/DeploymentPipeline.java
@@ -37,11 +37,8 @@ public interface DeploymentPipeline {
     /**
      * Does a deployment.
      *
-     * @param target    the target that needs to be deployed
-     * @param params    additional parameters that can be used by the processors of the pipeline
-     *
-     * @return the deployment info
+     * @param deployment    the deployment info
      */
-    Deployment execute(Target target, Map<String, Object> params);
+    void execute(Deployment deployment);
 
 }

--- a/src/main/java/org/craftercms/deployer/api/DeploymentProcessor.java
+++ b/src/main/java/org/craftercms/deployer/api/DeploymentProcessor.java
@@ -48,8 +48,7 @@ public interface DeploymentProcessor {
      * Executes the processor
      *
      * @param deployment    the current deployment info
-     * @param params        additional parameters that can be used by the processor
      */
-    void execute(Deployment deployment, Map<String, Object> params);
+    void execute(Deployment deployment);
 
 }

--- a/src/main/java/org/craftercms/deployer/api/DeploymentService.java
+++ b/src/main/java/org/craftercms/deployer/api/DeploymentService.java
@@ -39,7 +39,7 @@ public interface DeploymentService {
      *
      * @throws DeploymentServiceException if there was an error while executing the deployments
      */
-    List<Future<Deployment>> deployAllTargets(Map<String, Object> params) throws DeploymentServiceException;
+    List<Deployment> deployAllTargets(Map<String, Object> params) throws DeploymentServiceException;
 
     /**
      * Deploys a single target
@@ -52,7 +52,7 @@ public interface DeploymentService {
      *
      * @throws DeploymentServiceException if there was an error while executing the deployments
      */
-    Future<Deployment> deployTarget(String env, String siteName,
+    Deployment deployTarget(String env, String siteName,
                             Map<String, Object> params) throws TargetNotFoundException, DeploymentServiceException;
 
 }

--- a/src/main/java/org/craftercms/deployer/api/Target.java
+++ b/src/main/java/org/craftercms/deployer/api/Target.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.io.File;
 import java.time.ZonedDateTime;
+import java.util.Collection;
 import java.util.Map;
 
 import org.apache.commons.configuration2.Configuration;
@@ -85,6 +86,24 @@ public interface Target {
      * @param cronExpression    the cron expression
      */
     void scheduleDeployment(TaskScheduler scheduler, String cronExpression);
+
+    /**
+     * Returns the pending deployments.
+     */
+    @JsonIgnore
+    Collection<Deployment> getPendingDeployments();
+
+    /**
+     * Returns the current deployment.
+     */
+    @JsonIgnore
+    Deployment getCurrentDeployment();
+
+    /**
+     * Returns all deployments (pending and current).
+     */
+    @JsonIgnore
+    Collection<Deployment> getAllDeployments();
 
     /**
      * Closes the target and releases any open resources.

--- a/src/main/java/org/craftercms/deployer/impl/DeploymentPipelineFactoryImpl.java
+++ b/src/main/java/org/craftercms/deployer/impl/DeploymentPipelineFactoryImpl.java
@@ -22,7 +22,6 @@ import java.util.List;
 import org.apache.commons.configuration2.HierarchicalConfiguration;
 import org.craftercms.deployer.api.DeploymentPipeline;
 import org.craftercms.deployer.api.DeploymentProcessor;
-import org.craftercms.deployer.api.exceptions.DeployerConfigurationException;
 import org.craftercms.deployer.api.exceptions.DeployerException;
 import org.craftercms.deployer.utils.ConfigUtils;
 import org.slf4j.Logger;
@@ -47,7 +46,7 @@ public class DeploymentPipelineFactoryImpl implements DeploymentPipelineFactory 
     public DeploymentPipeline getPipeline(HierarchicalConfiguration configuration, ConfigurableApplicationContext applicationContext,
                                           String pipelinePropertyName) throws DeployerException {
         List<HierarchicalConfiguration> processorConfigs = ConfigUtils.getRequiredConfigurationsAt(configuration, pipelinePropertyName);
-        List<DeploymentProcessor> processors = new ArrayList<>();
+        List<DeploymentProcessor> deploymentProcessors = new ArrayList<>();
 
         for (HierarchicalConfiguration processorConfig : processorConfigs) {
             String processorName = ConfigUtils.getRequiredStringProperty(processorConfig, PROCESSOR_NAME_CONFIG_KEY);
@@ -58,7 +57,7 @@ public class DeploymentPipelineFactoryImpl implements DeploymentPipelineFactory 
                 DeploymentProcessor processor = applicationContext.getBean(processorName, DeploymentProcessor.class);
                 processor.init(processorConfig);
 
-                processors.add(processor);
+                deploymentProcessors.add(processor);
             } catch (NoSuchBeanDefinitionException e) {
                 throw new DeployerException("No processor prototype bean found with name '" + processorName + "'", e);
             } catch (Exception e) {
@@ -66,7 +65,7 @@ public class DeploymentPipelineFactoryImpl implements DeploymentPipelineFactory 
             }
         }
 
-        return new DeploymentPipelineImpl(processors);
+        return new DeploymentPipelineImpl(deploymentProcessors);
     }
 
 }

--- a/src/main/java/org/craftercms/deployer/impl/DeploymentPipelineImpl.java
+++ b/src/main/java/org/craftercms/deployer/impl/DeploymentPipelineImpl.java
@@ -23,7 +23,6 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.craftercms.deployer.api.Deployment;
 import org.craftercms.deployer.api.DeploymentPipeline;
 import org.craftercms.deployer.api.DeploymentProcessor;
-import org.craftercms.deployer.api.Target;
 import org.craftercms.deployer.api.exceptions.DeployerException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,16 +36,16 @@ public class DeploymentPipelineImpl implements DeploymentPipeline {
 
     private static final Logger logger = LoggerFactory.getLogger(DeploymentServiceImpl.class);
 
-    protected List<DeploymentProcessor> processors;
+    protected List<DeploymentProcessor> deploymentProcessors;
 
-    public DeploymentPipelineImpl(List<DeploymentProcessor> processors) {
-        this.processors = processors;
+    public DeploymentPipelineImpl(List<DeploymentProcessor> deploymentProcessors) {
+        this.deploymentProcessors = deploymentProcessors;
     }
 
     @Override
     public void destroy() throws DeployerException {
-        if (CollectionUtils.isNotEmpty(processors)) {
-            for (DeploymentProcessor processor : processors) {
+        if (CollectionUtils.isNotEmpty(deploymentProcessors)) {
+            for (DeploymentProcessor processor : deploymentProcessors) {
                 try {
                     processor.destroy();
                 } catch (Exception e) {
@@ -57,20 +56,18 @@ public class DeploymentPipelineImpl implements DeploymentPipeline {
     }
 
     @Override
-    public Deployment execute(Target target, Map<String, Object> params) {
-        Deployment deployment = new Deployment(target);
+    public void execute(Deployment deployment) {
+        deployment.start();
 
-        executeProcessors(deployment, params);
+        executeProcessors(deployment);
 
-        deployment.endDeployment(Deployment.Status.SUCCESS);
-
-        return deployment;
+        deployment.end(Deployment.Status.SUCCESS);
     }
 
-    protected void executeProcessors(Deployment deployment, Map<String, Object> params) {
-        if (CollectionUtils.isNotEmpty(processors)) {
-            for (DeploymentProcessor processor : processors) {
-                processor.execute(deployment, params);
+    protected void executeProcessors(Deployment deployment) {
+        if (CollectionUtils.isNotEmpty(deploymentProcessors)) {
+            for (DeploymentProcessor processor : deploymentProcessors) {
+                processor.execute(deployment);
             }
         }
     }

--- a/src/main/java/org/craftercms/deployer/impl/TargetServiceImpl.java
+++ b/src/main/java/org/craftercms/deployer/impl/TargetServiceImpl.java
@@ -35,7 +35,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.regex.Pattern;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 
@@ -295,10 +294,10 @@ public class TargetServiceImpl implements TargetService, ApplicationListener<App
             // Check if the YAML config file or the app context file have changed since target load.
             long yamlLastModified = configFile.exists() ? configFile.lastModified() : 0;
             long contextLastModified = contextFile.exists()? contextFile.lastModified() : 0;
-            long targetOpenedDate = target.getLoadDate().toInstant().toEpochMilli();
+            long targetLoadedDate = target.getLoadDate().toInstant().toEpochMilli();
 
             // Refresh if the files have been modified.
-            if (yamlLastModified >= targetOpenedDate || contextLastModified >= targetOpenedDate) {
+            if (yamlLastModified >= targetLoadedDate || contextLastModified >= targetLoadedDate) {
                 logger.info("Configuration files haven been updated for '{}'. The target will be reloaded.", target.getId());
 
                 target.close();

--- a/src/main/java/org/craftercms/deployer/impl/processors/AbstractMainDeploymentProcessor.java
+++ b/src/main/java/org/craftercms/deployer/impl/processors/AbstractMainDeploymentProcessor.java
@@ -56,7 +56,7 @@ public abstract class AbstractMainDeploymentProcessor extends AbstractDeployment
     }
 
     @Override
-    public void execute(Deployment deployment, Map<String, Object> params) {
+    public void execute(Deployment deployment) {
         ChangeSet filteredChangeSet = getFilteredChangeSet(deployment.getChangeSet());
         
         if (shouldExecute(deployment, filteredChangeSet)) {
@@ -67,7 +67,7 @@ public abstract class AbstractMainDeploymentProcessor extends AbstractDeployment
             try {
                 logger.info("----- {} @ {} -----", name, targetId);
 
-                ChangeSet processedChangeSet = doExecute(deployment, execution, filteredChangeSet, params);
+                ChangeSet processedChangeSet = doExecute(deployment, execution, filteredChangeSet);
                 if (processedChangeSet != null) {
                     deployment.setChangeSet(processedChangeSet);
                 }
@@ -80,7 +80,7 @@ public abstract class AbstractMainDeploymentProcessor extends AbstractDeployment
                 execution.endExecution(Deployment.Status.FAILURE);
 
                 if (failDeploymentOnProcessorFailure()) {
-                    deployment.endDeployment(Deployment.Status.FAILURE);
+                    deployment.end(Deployment.Status.FAILURE);
                 }
             }
         }
@@ -127,7 +127,7 @@ public abstract class AbstractMainDeploymentProcessor extends AbstractDeployment
     protected abstract void doInit(Configuration config) throws DeployerException;
 
     protected abstract ChangeSet doExecute(Deployment deployment, ProcessorExecution execution,
-                                           ChangeSet filteredChangeSet, Map<String, Object> params) throws DeployerException;
+                                           ChangeSet filteredChangeSet) throws DeployerException;
 
     protected abstract boolean failDeploymentOnProcessorFailure();
 

--- a/src/main/java/org/craftercms/deployer/impl/processors/AbstractPostDeploymentProcessor.java
+++ b/src/main/java/org/craftercms/deployer/impl/processors/AbstractPostDeploymentProcessor.java
@@ -34,14 +34,14 @@ public abstract class AbstractPostDeploymentProcessor extends AbstractDeployment
     private static final Logger logger = LoggerFactory.getLogger(AbstractPostDeploymentProcessor.class);
 
     @Override
-    public void execute(Deployment deployment, Map<String, Object> params) {
-        deployment.endDeployment(Deployment.Status.SUCCESS);
+    public void execute(Deployment deployment) {
+        deployment.end(Deployment.Status.SUCCESS);
 
         if (shouldExecute(deployment)) {
             try {
                 logger.info("----- {} @ {} -----", name, targetId);
 
-                doExecute(deployment, params);
+                doExecute(deployment);
             } catch (Exception e) {
                 logger.error("Processor '" + name + "' for target '" + targetId + "' failed", e);
             }
@@ -53,6 +53,6 @@ public abstract class AbstractPostDeploymentProcessor extends AbstractDeployment
         return deployment.getStatus() == Deployment.Status.FAILURE || !deployment.isChangeSetEmpty();
     }
 
-    protected abstract void doExecute(Deployment deployment, Map<String, Object> params) throws DeployerException;
+    protected abstract void doExecute(Deployment deployment) throws DeployerException;
 
 }

--- a/src/main/java/org/craftercms/deployer/impl/processors/FileOutputProcessor.java
+++ b/src/main/java/org/craftercms/deployer/impl/processors/FileOutputProcessor.java
@@ -22,7 +22,6 @@ import java.io.File;
 import java.io.IOException;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.Map;
 
 import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.io.FileUtils;
@@ -42,7 +41,7 @@ public class FileOutputProcessor extends AbstractPostDeploymentProcessor {
 
     private static final Logger logger = LoggerFactory.getLogger(FileOutputProcessor.class);
 
-    public static final String OUTPUT_FILE_ATTRIBUTE_NAME = "outputFile";
+    public static final String OUTPUT_FILE_PARAM_NAME = "outputFile";
 
     protected File outputFolder;
     protected String timestampPattern;
@@ -91,7 +90,7 @@ public class FileOutputProcessor extends AbstractPostDeploymentProcessor {
     }
 
     @Override
-    protected void doExecute(Deployment deployment, Map<String, Object> params) throws DeployerException {
+    protected void doExecute(Deployment deployment) throws DeployerException {
         File outputFile = getOutputFile(deployment);
 
         try {
@@ -100,7 +99,7 @@ public class FileOutputProcessor extends AbstractPostDeploymentProcessor {
             throw new DeployerException("Error while writing deployment output file " + outputFile, e);
         }
 
-        deployment.addAttribute(OUTPUT_FILE_ATTRIBUTE_NAME, outputFile);
+        deployment.addParam(OUTPUT_FILE_PARAM_NAME, outputFile);
 
         logger.info("Successfully wrote deployment output to {}", outputFile);
     }

--- a/src/main/java/org/craftercms/deployer/impl/processors/GitDiffProcessor.java
+++ b/src/main/java/org/craftercms/deployer/impl/processors/GitDiffProcessor.java
@@ -99,8 +99,8 @@ public class GitDiffProcessor extends AbstractMainDeploymentProcessor {
 
     @Override
     protected ChangeSet doExecute(Deployment deployment, ProcessorExecution execution,
-                                  ChangeSet filteredChangeSet, Map<String, Object> params) throws DeployerException {
-        boolean reprocessAllFiles = getReprocessAllFilesParam(params);
+                                  ChangeSet filteredChangeSet) throws DeployerException {
+        boolean reprocessAllFiles = getReprocessAllFilesParam(deployment);
         if (reprocessAllFiles) {
             processedCommitsStore.delete(targetId);
 
@@ -255,13 +255,13 @@ public class GitDiffProcessor extends AbstractMainDeploymentProcessor {
         return path;
     }
 
-    protected boolean getReprocessAllFilesParam(Map<String, Object> params) {
-        if (MapUtils.isNotEmpty(params)) {
-            Object value = params.get(REPROCESS_ALL_FILES_PARAM_NAME);
+    protected boolean getReprocessAllFilesParam(Deployment deployment) {
+        Object value = deployment.getParam(REPROCESS_ALL_FILES_PARAM_NAME);
+        if (value != null) {
             if (value instanceof Boolean) {
                 return (Boolean)value;
             } else {
-                return value != null && BooleanUtils.toBoolean(value.toString());
+                return BooleanUtils.toBoolean(value.toString());
             }
         } else {
             return false;

--- a/src/main/java/org/craftercms/deployer/impl/processors/GitPullProcessor.java
+++ b/src/main/java/org/craftercms/deployer/impl/processors/GitPullProcessor.java
@@ -116,7 +116,7 @@ public class GitPullProcessor extends AbstractMainDeploymentProcessor {
 
     @Override
     protected ChangeSet doExecute(Deployment deployment, ProcessorExecution execution,
-                                  ChangeSet filteredChangeSet, Map<String, Object> params) throws DeployerException {
+                                  ChangeSet filteredChangeSet) throws DeployerException {
         File gitFolder = new File(localRepoFolder, GIT_FOLDER_NAME);
 
         if (localRepoFolder.exists() && gitFolder.exists()) {

--- a/src/main/java/org/craftercms/deployer/impl/processors/HttpMethodCallProcessor.java
+++ b/src/main/java/org/craftercms/deployer/impl/processors/HttpMethodCallProcessor.java
@@ -80,7 +80,7 @@ public class HttpMethodCallProcessor extends AbstractMainDeploymentProcessor {
 
     @Override
     protected ChangeSet doExecute(Deployment deployment, ProcessorExecution execution,
-                                  ChangeSet filteredChangeSet, Map<String, Object> params) throws DeployerException {
+                                  ChangeSet filteredChangeSet) throws DeployerException {
         HttpUriRequest request = createRequest();
 
         logger.info("Executing request {}...", request);

--- a/src/main/java/org/craftercms/deployer/impl/processors/MailNotificationProcessor.java
+++ b/src/main/java/org/craftercms/deployer/impl/processors/MailNotificationProcessor.java
@@ -142,7 +142,7 @@ public class MailNotificationProcessor extends AbstractPostDeploymentProcessor {
     }
 
     @Override
-    protected void doExecute(Deployment deployment, Map<String, Object> params) throws DeployerException {
+    protected void doExecute(Deployment deployment) throws DeployerException {
         Map<String, Object> templateModel = new HashMap<>();
         templateModel.put(SERVER_NAME_MODEL_KEY, serverName);
         templateModel.put(TARGET_ID_MODEL_KEY, deployment.getTarget().getId());
@@ -150,7 +150,7 @@ public class MailNotificationProcessor extends AbstractPostDeploymentProcessor {
         templateModel.put(END_MODEL_KEY, deployment.getEnd().format(dateTimeFormatter));
         templateModel.put(STATUS_MODEL_KEY, deployment.getStatus());
 
-        File attachment = (File)deployment.getAttribute(FileOutputProcessor.OUTPUT_FILE_ATTRIBUTE_NAME);
+        File attachment = (File)deployment.getParam(FileOutputProcessor.OUTPUT_FILE_PARAM_NAME);
 
         templateModel.put(OUTPUT_ATTACHED_MODEL_KEY, attachment != null);
 

--- a/src/main/java/org/craftercms/deployer/impl/processors/SearchIndexingProcessor.java
+++ b/src/main/java/org/craftercms/deployer/impl/processors/SearchIndexingProcessor.java
@@ -129,7 +129,7 @@ public class SearchIndexingProcessor extends AbstractMainDeploymentProcessor {
 
     @Override
     protected ChangeSet doExecute(Deployment deployment, ProcessorExecution execution,
-                                  ChangeSet filteredChangeSet, Map<String, Object> params) throws DeployerException {
+                                  ChangeSet filteredChangeSet) throws DeployerException {
         logger.info("Performing search indexing...");
 
         ChangeSet changeSet = deployment.getChangeSet();

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -70,6 +70,6 @@ deployer:
     logging:
       # The folder path where log files are written to
       folderPath: ${deployer.main.homePath}/logs
-    scheduling:
-      # Thread pool size used when scheduling deployments
+    taskScheduler:
+      # Thread pool size of the task scheduler
       poolSize: 10


### PR DESCRIPTION
* Refactored deployment so now each Target has it's own executor. When a new deployment is requested a deployment task is submitted to the executor. If the executor is already running a deployment it will be put on a queue.
* Target now has methods that return the current, the pending and all deployments for a Target.
* Added API endpoints to retrieve the current, the pending and all deployments for a Target ([deployer] Provide API to monitor current running deployments #1065).