### PR TITLE
Updated spring-boot-maven-plugin configuration:

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -201,6 +201,19 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+				<configuration>
+					<layout>ZIP</layout>
+				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>repackage</goal>
+						</goals>
+						<configuration>
+							<classifier>exec</classifier>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
- Changed layout to allow external jars to be loaded
- Changed classifier to allow the jar to be used as dependency in other projects

https://github.com/craftercms/craftercms/issues/2041
