### PR TITLE
 Create target API param added

### DIFF
--- a/src/main/resources/templates/targets/remote-target-template.yaml
+++ b/src/main/resources/templates/targets/remote-target-template.yaml
@@ -24,6 +24,7 @@ target:
           ssh:
             privateKey:
               path: {{ssh_private_key_path}}
+              passphrase: {{ssh_private_key_passphrase}}
           {{/if}}
       - processorName: gitDiffProcessor
       - processorName: searchIndexingProcessor


### PR DESCRIPTION
* The remote-target-template.yaml now accepts an `ssh_private_key_passphrase` passed down by the create target API call.

Ticket craftercms/craftercms#2079
