### PR TITLE
 Added base class for git pull/push processors:

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 	<properties>
 		<!-- Version Numbers -->
 		<commons.configuration.version>2.1</commons.configuration.version>
-		<jgit.version>4.11.0.201803080745-r</jgit.version>
+		<jgit.version>4.8.0.201705170830-rc1</jgit.version>
 		<snakeyaml.version>1.17</snakeyaml.version>
 		<jackson.version>2.8.11</jackson.version>
 		<javax.mail.version>1.4.7</javax.mail.version>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 	<properties>
 		<!-- Version Numbers -->
 		<commons.configuration.version>2.1</commons.configuration.version>
-		<jgit.version>4.8.0.201705170830-rc1</jgit.version>
+		<jgit.version>4.11.0.201803080745-r</jgit.version>
 		<snakeyaml.version>1.17</snakeyaml.version>
 		<jackson.version>2.8.11</jackson.version>
 		<javax.mail.version>1.4.7</javax.mail.version>

--- a/src/main/java/org/craftercms/deployer/impl/processors/AbstractMainDeploymentProcessor.java
+++ b/src/main/java/org/craftercms/deployer/impl/processors/AbstractMainDeploymentProcessor.java
@@ -65,7 +65,7 @@ public abstract class AbstractMainDeploymentProcessor extends AbstractDeployment
             deployment.addProcessorExecution(execution);
 
             try {
-                logger.info("----- {} @ {} -----", name, targetId);
+                logger.info("----- < {} @ {} > -----", name, targetId);
 
                 ChangeSet processedChangeSet = doExecute(deployment, execution, filteredChangeSet);
                 if (processedChangeSet != null) {

--- a/src/main/java/org/craftercms/deployer/impl/processors/AbstractPostDeploymentProcessor.java
+++ b/src/main/java/org/craftercms/deployer/impl/processors/AbstractPostDeploymentProcessor.java
@@ -37,7 +37,7 @@ public abstract class AbstractPostDeploymentProcessor extends AbstractDeployment
 
         if (shouldExecute(deployment)) {
             try {
-                logger.info("----- {} @ {} -----", name, targetId);
+                logger.info("----- < {} @ {} > -----", name, targetId);
 
                 doExecute(deployment);
             } catch (Exception e) {

--- a/src/main/java/org/craftercms/deployer/impl/processors/GitPullProcessor.java
+++ b/src/main/java/org/craftercms/deployer/impl/processors/GitPullProcessor.java
@@ -21,15 +21,9 @@ import java.io.IOException;
 
 import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.craftercms.commons.git.auth.BasicUsernamePasswordAuthConfigurator;
-import org.craftercms.commons.git.auth.GitAuthenticationConfigurator;
-import org.craftercms.commons.git.auth.SshRsaKeyPairAuthConfigurator;
-import org.craftercms.commons.git.auth.SshUsernamePasswordAuthConfigurator;
 import org.craftercms.deployer.api.ChangeSet;
 import org.craftercms.deployer.api.Deployment;
 import org.craftercms.deployer.api.ProcessorExecution;
-import org.craftercms.deployer.api.exceptions.DeployerConfigurationException;
 import org.craftercms.deployer.api.exceptions.DeployerException;
 import org.craftercms.deployer.utils.ConfigUtils;
 import org.craftercms.deployer.utils.GitUtils;
@@ -40,77 +34,39 @@ import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.merge.MergeStrategy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Required;
 
 /**
- * Processor that clones/pulls a remote Git repository into a local path in the filesystem. It uses a
- * {@link GitAuthenticationConfigurator}
- * to configure the Git connection authentication. A processor instance can be configured with the following YAML
- * properties:
- * <p>
+ * Processor that clones/pulls a remote Git repository into a local path in the filesystem. A processor instance
+ * can be configured with the following YAML properties:
+ *
  * <ul>
- * <li><strong>remoteRepo.url:</strong> The URL of the remote Git repo to clone/pull</li>
- * <li><strong>remoteRepo.branch:</strong> The branch of the remote Git repo to clone/pull</li>
- * <li><strong>remoteRepo.username:</strong> The username for authentication with the remote Git repo. Not needed when
- * SSH with RSA key pair authentication is used.</li>
- * <li><strong>remoteRepo.password:</strong> The password for authentication with the remote Git repo. Not needed when
- * SSH with RSA key pair authentication is used.</li>
- * <li><strong>remoteRepo.ssh.privateKey.path:</strong> The SSH private key path, used only with SSH with RSA key pair
- * authentication.</li>
- * <li><strong>remoteRepo.ssh.privateKey.passphrase:</strong> The SSH private key passphrase, used only with SSH with
- * RSA key pair authentication.</li>
+ *     <li><strong>remoteRepo.url:</strong> The URL of the remote Git repo to pull.</li>
+ *     <li><strong>remoteRepo.branch:</strong> The branch of the remote Git repo to pull.</li>
+ *     <li><strong>remoteRepo.username:</strong> The username for authentication with the remote Git repo.
+ *     Not needed when SSH with RSA key pair authentication is used.</li>
+ *     <li><strong>remoteRepo.password:</strong> The password for authentication with the remote Git repo.
+ *     Not needed when SSH with RSA key pair authentication is used.</li>
+ *     <li><strong>remoteRepo.ssh.privateKey.path:</strong> The SSH private key path, used only with SSH with RSA
+ *     key pair authentication.</li>
+ *     <li><strong>remoteRepo.ssh.privateKey.passphrase:</strong> The SSH private key passphrase, used only with
+ *     SSH withRSA key pair authentication.</li>
  * </ul>
  *
  * @author avasquez
  */
-public class GitPullProcessor extends AbstractMainDeploymentProcessor {
-
-    public static final String REMOTE_REPO_URL_CONFIG_KEY = "remoteRepo.url";
-    public static final String REMOTE_REPO_BRANCH_CONFIG_KEY = "remoteRepo.branch";
-    public static final String REMOTE_REPO_USERNAME_CONFIG_KEY = "remoteRepo.username";
-    public static final String REMOTE_REPO_PASSWORD_CONFIG_KEY = "remoteRepo.password";
-    public static final String REMOTE_REPO_SSH_PRV_KEY_PATH_CONFIG_KEY = "remoteRepo.ssh.privateKey.path";
-    public static final String REMOTE_REPO_SSH_PRV_KEY_PASSPHRASE_CONFIG_KEY = "remoteRepo.ssh.privateKey.passphrase";
-
-    public static final String GIT_FOLDER_NAME = ".git";
+public class GitPullProcessor extends RemoteGitRepoAwareProcessor {
 
     private static final Logger logger = LoggerFactory.getLogger(GitPullProcessor.class);
 
-    protected File localRepoFolder;
-
-    protected String remoteRepoUrl;
-    protected String remoteRepoBranch;
-    protected GitAuthenticationConfigurator authenticationConfigurator;
-
-    /**
-     * Sets the local filesystem folder that will contain the remote repo clone.
-     */
-    @Required
-    public void setLocalRepoFolder(File localRepoFolder) {
-        this.localRepoFolder = localRepoFolder;
-    }
-
     @Override
-    protected void doInit(Configuration config) throws DeployerException {
-        remoteRepoUrl = ConfigUtils.getRequiredStringProperty(config, REMOTE_REPO_URL_CONFIG_KEY);
-        remoteRepoBranch = ConfigUtils.getStringProperty(config, REMOTE_REPO_BRANCH_CONFIG_KEY);
-        authenticationConfigurator = createAuthenticationConfigurator(config, remoteRepoUrl);
-    }
-
-    @Override
-    public void destroy() throws DeployerException {
-    }
-
-    @Override
-    protected boolean shouldExecute(Deployment deployment, ChangeSet filteredChangeSet) {
-        // Run if the deployment is running
-        return deployment.isRunning();
+    protected boolean failDeploymentOnProcessorFailure() {
+        return true;
     }
 
     @Override
     protected ChangeSet doExecute(Deployment deployment, ProcessorExecution execution,
                                   ChangeSet filteredChangeSet) throws DeployerException {
-        File gitFolder = new File(localRepoFolder, GIT_FOLDER_NAME);
+        File gitFolder = new File(localRepoFolder, GitUtils.GIT_FOLDER_NAME);
 
         if (localRepoFolder.exists() && gitFolder.exists()) {
             doPull(execution);
@@ -119,11 +75,6 @@ public class GitPullProcessor extends AbstractMainDeploymentProcessor {
         }
 
         return null;
-    }
-
-    @Override
-    protected boolean failDeploymentOnProcessorFailure() {
-        return true;
     }
 
     protected void doPull(ProcessorExecution execution) throws DeployerException {
@@ -161,20 +112,10 @@ public class GitPullProcessor extends AbstractMainDeploymentProcessor {
                            remoteRepoUrl + ") (merge result with status " + status + ")";
                 default:
                     // Non-supported merge results
-                    throw new DeployerException("Received unsupported merge result after executing pull: " + status);
+                    throw new DeployerException("Received unexpected merge result after executing pull: " + status);
             }
         } else {
             throw new DeployerException("Merge failed with status " + status);
-        }
-    }
-
-    protected Git openLocalRepository() throws DeployerException {
-        try {
-            logger.debug("Opening local Git repository at {}", localRepoFolder);
-
-            return GitUtils.openRepository(localRepoFolder);
-        } catch (IOException e) {
-            throw new DeployerException("Failed to open Git repository at " + localRepoFolder, e);
         }
     }
 
@@ -211,45 +152,6 @@ public class GitPullProcessor extends AbstractMainDeploymentProcessor {
             throw new DeployerException(
                 "Failed to clone Git remote repository " + remoteRepoUrl + " into " + localRepoFolder, e);
         }
-    }
-
-    protected GitAuthenticationConfigurator createAuthenticationConfigurator(Configuration config,
-                                                                             String repoUrl) throws
-        DeployerConfigurationException {
-        GitAuthenticationConfigurator authConfigurator = null;
-
-        if (repoUrl.startsWith("ssh:")) {
-            String password = ConfigUtils.getStringProperty(config, REMOTE_REPO_PASSWORD_CONFIG_KEY);
-
-            if (StringUtils.isNotEmpty(password)) {
-                logger.debug("SSH username/password authentication will be used to connect to repo {}", repoUrl);
-
-                authConfigurator = new SshUsernamePasswordAuthConfigurator(password);
-            } else {
-                String privateKeyPath = ConfigUtils.getStringProperty(config, REMOTE_REPO_SSH_PRV_KEY_PATH_CONFIG_KEY);
-                String passphrase = ConfigUtils.getStringProperty(config,
-                                                                  REMOTE_REPO_SSH_PRV_KEY_PASSPHRASE_CONFIG_KEY);
-
-                logger.debug("SSH RSA key pair authentication will be used to connect to repo {}", repoUrl);
-
-                SshRsaKeyPairAuthConfigurator keyPairAuthConfigurator = new SshRsaKeyPairAuthConfigurator();
-                keyPairAuthConfigurator.setPrivateKeyPath(privateKeyPath);
-                keyPairAuthConfigurator.setPassphrase(passphrase);
-
-                authConfigurator = keyPairAuthConfigurator;
-            }
-        } else {
-            String username = ConfigUtils.getStringProperty(config, REMOTE_REPO_USERNAME_CONFIG_KEY);
-            String password = ConfigUtils.getStringProperty(config, REMOTE_REPO_PASSWORD_CONFIG_KEY);
-
-            if (StringUtils.isNotEmpty(username) && StringUtils.isNotEmpty(password)) {
-                logger.debug("Username/password authentication will be used to connect to repo {}", repoUrl);
-
-                authConfigurator = new BasicUsernamePasswordAuthConfigurator(username, password);
-            }
-        }
-
-        return authConfigurator;
     }
 
 }

--- a/src/main/java/org/craftercms/deployer/impl/processors/GitPushProcessor.java
+++ b/src/main/java/org/craftercms/deployer/impl/processors/GitPushProcessor.java
@@ -17,161 +17,138 @@
 package org.craftercms.deployer.impl.processors;
 
 import java.io.File;
-import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
-import org.apache.commons.configuration2.Configuration;
-import org.apache.commons.lang3.StringUtils;
-import org.craftercms.commons.git.auth.BasicUsernamePasswordAuthConfigurator;
-import org.craftercms.commons.git.auth.GitAuthenticationConfigurator;
-import org.craftercms.commons.git.auth.SshRsaKeyPairAuthConfigurator;
-import org.craftercms.commons.git.auth.SshUsernamePasswordAuthConfigurator;
+import org.apache.commons.collections4.CollectionUtils;
 import org.craftercms.deployer.api.ChangeSet;
 import org.craftercms.deployer.api.Deployment;
 import org.craftercms.deployer.api.ProcessorExecution;
-import org.craftercms.deployer.api.exceptions.DeployerConfigurationException;
 import org.craftercms.deployer.api.exceptions.DeployerException;
-import org.craftercms.deployer.utils.ConfigUtils;
 import org.craftercms.deployer.utils.GitUtils;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.transport.PushResult;
+import org.eclipse.jgit.transport.RemoteRefUpdate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Required;
+
+import static org.craftercms.deployer.api.Deployment.Status;
 
 /**
- * Processor that pushes a localRepo to a remote Git repository. It uses a {@link GitAuthenticationConfigurator}
- * to configure the Git connection authentication. A processor instance can be configured with the following YAML properties:
+ * Processor that pushes a localRepo to a remote Git repository. A processor instance can be configured with the
+ * following YAML properties:
  *
  * <ul>
- *     <li><strong>remoteRepo.url:</strong> The URL of the remote Git repo to push to</li>
- *     <li><strong>remoteRepo.username:</strong> The username for authentication with the remote Git repo. Not needed when
- *     SSH with RSA key pair authentication is used.</li>
- *     <li><strong>remoteRepo.password:</strong> The password for authentication with the remote Git repo. Not needed when
- *     SSH with RSA key pair authentication is used.</li>
- *     <li><strong>remoteRepo.ssh.privateKey.path:</strong> The SSH private key path, used only with SSH with RSA key pair
- *     authentication.</li>
- *     <li><strong>remoteRepo.ssh.privateKey.passphrase:</strong> The SSH private key passphrase, used only with SSH with
- *     RSA key pair authentication.</li>
+ *     <li><strong>localRepoBranch:</strong> The branch of the local repo to push.</li>
+ *     <li><strong>remoteRepo.url:</strong> The URL of the remote Git repo to push to.</li>
+ *     <li><strong>remoteRepo.branch:</strong> The branch of the remote Git repo to push to.</li>
+ *     <li><strong>remoteRepo.username:</strong> The username for authentication with the remote Git repo.
+ *     Not needed when SSH with RSA key pair authentication is used.</li>
+ *     <li><strong>remoteRepo.password:</strong> The password for authentication with the remote Git repo.
+ *     Not needed when SSH with RSA key pair authentication is used.</li>
+ *     <li><strong>remoteRepo.ssh.privateKey.path:</strong> The SSH private key path, used only with SSH with RSA
+ *     key pair authentication.</li>
+ *     <li><strong>remoteRepo.ssh.privateKey.passphrase:</strong> The SSH private key passphrase, used only with
+ *     SSH withRSA key pair authentication.</li>
  * </ul>
  *
  * @author avasquez
  */
-public class GitPushProcessor extends AbstractMainDeploymentProcessor {
-
-    public static final String REMOTE_REPO_URL_CONFIG_KEY = "remoteRepo.url";
-    public static final String REMOTE_REPO_USERNAME_CONFIG_KEY = "remoteRepo.username";
-    public static final String REMOTE_REPO_PASSWORD_CONFIG_KEY = "remoteRepo.password";
-    public static final String REMOTE_REPO_SSH_PRV_KEY_PATH_CONFIG_KEY = "remoteRepo.ssh.privateKey.path";
-    public static final String REMOTE_REPO_SSH_PRV_KEY_PASSPHRASE_CONFIG_KEY = "remoteRepo.ssh.privateKey.passphrase";
-
-    public static final String GIT_FOLDER_NAME = ".git";
+public class GitPushProcessor extends RemoteGitRepoAwareProcessor {
 
     private static final Logger logger = LoggerFactory.getLogger(GitPushProcessor.class);
-
-    protected File localRepoFolder;
-    protected String remoteRepoUrl;
-    protected String remoteRepoBranch;
-    protected GitAuthenticationConfigurator authenticationConfigurator;
-
-    /**
-     * Sets the local filesystem folder that will contain the remote repo clone.
-     */
-    @Required
-    public void setLocalRepoFolder(File localRepoFolder) {
-        this.localRepoFolder = localRepoFolder;
-    }
-
-    @Override
-    protected void doInit(Configuration config) throws DeployerException {
-        remoteRepoUrl = ConfigUtils.getRequiredStringProperty(config, REMOTE_REPO_URL_CONFIG_KEY);
-        authenticationConfigurator = createAuthenticationConfigurator(config, remoteRepoUrl);
-    }
-
-    @Override
-    public void destroy() throws DeployerException {
-    }
-
-    @Override
-    protected boolean shouldExecute(Deployment deployment, ChangeSet filteredChangeSet) {
-        // Run if the deployment is running
-        return deployment.isRunning();
-    }
 
     @Override
     protected ChangeSet doExecute(Deployment deployment, ProcessorExecution execution,
                                   ChangeSet filteredChangeSet) throws DeployerException {
-        File gitFolder = new File(localRepoFolder, GIT_FOLDER_NAME);
+        File gitFolder = new File(localRepoFolder, GitUtils.GIT_FOLDER_NAME);
 
         if (localRepoFolder.exists() && gitFolder.exists()) {
             doPush(execution);
         } else {
-        	logger.warn("No local git repository {}", localRepoFolder);
+        	logger.warn("No local git repository @ {}", localRepoFolder);
         }
 
         return null;
-    }
-
-    @Override
-    protected boolean failDeploymentOnProcessorFailure() {
-        return true;
     }
 
     protected void doPush(ProcessorExecution execution) throws DeployerException {
         try (Git git = openLocalRepository()) {
             logger.info("Executing git push for repository {}...", localRepoFolder);
 
-            GitUtils.push(git, this.remoteRepoUrl, true, authenticationConfigurator);
+            Iterable<PushResult> pushResults = GitUtils.push(git, remoteRepoUrl, remoteRepoBranch,
+                                                             authenticationConfigurator);
+            List<String> detailsList = new ArrayList<>();
 
-        } catch (GitAPIException e) {
-            throw new DeployerException("Execution of git push failed:", e);
-        }
-    }
+            boolean success = checkPushResults(pushResults, detailsList);
 
-    protected Git openLocalRepository() throws DeployerException {
-        try {
-            logger.debug("Opening local Git repository at {}", localRepoFolder);
+            if (CollectionUtils.isNotEmpty(detailsList)) {
+                execution.setStatusDetails(detailsList);
 
-            return GitUtils.openRepository(localRepoFolder);
-        } catch (IOException e) {
-            throw new DeployerException("Failed to open Git repository at " + localRepoFolder, e);
-        }
-    }
-
-     protected GitAuthenticationConfigurator createAuthenticationConfigurator(Configuration config,
-                                                                             String repoUrl) throws DeployerConfigurationException {
-        GitAuthenticationConfigurator authConfigurator = null;
-
-        if (repoUrl.startsWith("ssh:")) {
-            String password = ConfigUtils.getStringProperty(config, REMOTE_REPO_PASSWORD_CONFIG_KEY);
-
-            if (StringUtils.isNotEmpty(password)) {
-                logger.debug("SSH username/password authentication will be used to connect to repo {}", repoUrl);
-
-                authConfigurator = new SshUsernamePasswordAuthConfigurator(password);
+                if (!success) {
+                    execution.endExecution(Status.FAILURE);
+                }
             } else {
-                String privateKeyPath = ConfigUtils.getStringProperty(config, REMOTE_REPO_SSH_PRV_KEY_PATH_CONFIG_KEY);
-                String passphrase = ConfigUtils.getStringProperty(config, REMOTE_REPO_SSH_PRV_KEY_PASSPHRASE_CONFIG_KEY);
-
-                logger.debug("SSH RSA key pair authentication will be used to connect to repo {}", repoUrl);
-
-                SshRsaKeyPairAuthConfigurator keyPairAuthConfigurator = new SshRsaKeyPairAuthConfigurator();
-                keyPairAuthConfigurator.setPrivateKeyPath(privateKeyPath);
-                keyPairAuthConfigurator.setPassphrase(passphrase);
-
-                authConfigurator = keyPairAuthConfigurator;
+                execution.setStatusDetails("Not push result returned after pull operation");
             }
-        } else {
-            String username = ConfigUtils.getStringProperty(config, REMOTE_REPO_USERNAME_CONFIG_KEY);
-            String password = ConfigUtils.getStringProperty(config, REMOTE_REPO_PASSWORD_CONFIG_KEY);
+        } catch (GitAPIException e) {
+            throw new DeployerException("Execution of git push failed", e);
+        }
+    }
 
-            if (StringUtils.isNotEmpty(username) && StringUtils.isNotEmpty(password)) {
-                logger.debug("Username/password authentication will be used to connect to repo {}", repoUrl);
+    protected boolean checkPushResults(Iterable<PushResult> pushResults,
+                                       List<String> detailList) throws DeployerException {
+        boolean success = true;
 
-                authConfigurator = new BasicUsernamePasswordAuthConfigurator(username, password);
+        if (pushResults != null) {
+            for (PushResult result : pushResults) {
+                Collection<RemoteRefUpdate> remoteRefUpdates = result.getRemoteUpdates();
+                if (CollectionUtils.isNotEmpty(remoteRefUpdates)) {
+                    for (RemoteRefUpdate update : remoteRefUpdates) {
+                        if (!checkRemoteRefUpdate(update, detailList)) {
+                            success = false;
+                        }
+                    }
+                }
             }
         }
 
-        return authConfigurator;
+        return success;
+    }
+
+    protected boolean checkRemoteRefUpdate(RemoteRefUpdate update, List<String> detailList) throws DeployerException {
+        RemoteRefUpdate.Status status = update.getStatus();
+        String updatedBranch = update.getRemoteName();
+        String details;
+
+        switch (status) {
+            case OK:
+                details = "Branch '" + updatedBranch + "' of remote repo " + remoteRepoUrl + " updated " +
+                          "successfully (update with status " + status + ")";
+                detailList.add(details);
+
+                logger.info(details);
+
+                return true;
+            case UP_TO_DATE:
+                details = "Branch '" + updatedBranch + "' of remote repo " + remoteRepoUrl + " already up " +
+                          "to date (update with status " + status + ")";
+                detailList.add(details);
+
+                logger.info(details);
+
+                return true;
+            default:
+                // Non-supported push results
+                details = "Received unexpected result after executing push: " + status;
+                detailList.add(details);
+
+                logger.error(details);
+
+                return false;
+        }
     }
 
 }

--- a/src/main/java/org/craftercms/deployer/impl/processors/RemoteGitRepoAwareProcessor.java
+++ b/src/main/java/org/craftercms/deployer/impl/processors/RemoteGitRepoAwareProcessor.java
@@ -88,6 +88,7 @@ public abstract class RemoteGitRepoAwareProcessor extends AbstractMainDeployment
 
     @Override
     public void destroy() throws DeployerException {
+        // Do nothing
     }
 
     @Override

--- a/src/main/java/org/craftercms/deployer/impl/processors/RemoteGitRepoAwareProcessor.java
+++ b/src/main/java/org/craftercms/deployer/impl/processors/RemoteGitRepoAwareProcessor.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (C) 2007-2018 Crafter Software Corporation. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.craftercms.deployer.impl.processors;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.commons.configuration2.Configuration;
+import org.apache.commons.lang3.StringUtils;
+import org.craftercms.commons.git.auth.BasicUsernamePasswordAuthConfigurator;
+import org.craftercms.commons.git.auth.GitAuthenticationConfigurator;
+import org.craftercms.commons.git.auth.SshRsaKeyPairAuthConfigurator;
+import org.craftercms.commons.git.auth.SshUsernamePasswordAuthConfigurator;
+import org.craftercms.deployer.api.ChangeSet;
+import org.craftercms.deployer.api.Deployment;
+import org.craftercms.deployer.api.exceptions.DeployerConfigurationException;
+import org.craftercms.deployer.api.exceptions.DeployerException;
+import org.craftercms.deployer.utils.ConfigUtils;
+import org.craftercms.deployer.utils.GitUtils;
+import org.eclipse.jgit.api.Git;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Required;
+
+/**
+ * Base class for processors that work against a remote repo. It basically provides the code that is used to
+ * authenticate to the remote repository. A processor instance can be configured with the following YAML
+ * properties:
+ *
+ * <ul>
+ *     <li><strong>remoteRepo.url:</strong> The URL of the remote Git repo.</li>
+ *     <li><strong>remoteRepo.branch:</strong> The branch of the remote Git repo.</li>
+ *     <li><strong>remoteRepo.username:</strong> The username for authentication with the remote Git repo.
+ *     Not needed when SSH with RSA key pair authentication is used.</li>
+ *     <li><strong>remoteRepo.password:</strong> The password for authentication with the remote Git repo.
+ *     Not needed when SSH with RSA key pair authentication is used.</li>
+ *     <li><strong>remoteRepo.ssh.privateKey.path:</strong> The SSH private key path, used only with SSH with RSA
+ *     key pair authentication.</li>
+ *     <li><strong>remoteRepo.ssh.privateKey.passphrase:</strong> The SSH private key passphrase, used only with
+ *     SSH withRSA key pair authentication.</li>
+ * </ul>
+ *
+ * @author avasquez
+ */
+public abstract class RemoteGitRepoAwareProcessor extends AbstractMainDeploymentProcessor {
+
+    public static final String REMOTE_REPO_URL_CONFIG_KEY = "remoteRepo.url";
+    public static final String REMOTE_REPO_BRANCH_CONFIG_KEY = "remoteRepo.branch";
+    public static final String REMOTE_REPO_USERNAME_CONFIG_KEY = "remoteRepo.username";
+    public static final String REMOTE_REPO_PASSWORD_CONFIG_KEY = "remoteRepo.password";
+    public static final String REMOTE_REPO_SSH_PRV_KEY_PATH_CONFIG_KEY = "remoteRepo.ssh.privateKey.path";
+    public static final String REMOTE_REPO_SSH_PRV_KEY_PASSPHRASE_CONFIG_KEY = "remoteRepo.ssh.privateKey.passphrase";
+
+    public static final String GIT_SSH_URL_REGEX = "^(ssh://.+)|([a-zA-Z0-9._-]+@.+)$";
+
+    private static final Logger logger = LoggerFactory.getLogger(GitPullProcessor.class);
+
+    protected File localRepoFolder;
+    protected String remoteRepoUrl;
+    protected String remoteRepoBranch;
+    protected GitAuthenticationConfigurator authenticationConfigurator;
+
+    @Required
+    public void setLocalRepoFolder(File localRepoFolder) {
+        this.localRepoFolder = localRepoFolder;
+    }
+
+    @Override
+    protected void doInit(Configuration config) throws DeployerException {
+        remoteRepoUrl = ConfigUtils.getRequiredStringProperty(config, REMOTE_REPO_URL_CONFIG_KEY);
+        remoteRepoBranch = ConfigUtils.getStringProperty(config, REMOTE_REPO_BRANCH_CONFIG_KEY);
+        authenticationConfigurator = createAuthenticationConfigurator(config, remoteRepoUrl);
+    }
+
+    @Override
+    public void destroy() throws DeployerException {
+    }
+
+    @Override
+    protected boolean failDeploymentOnProcessorFailure() {
+        return false;
+    }
+
+    @Override
+    protected boolean shouldExecute(Deployment deployment, ChangeSet filteredChangeSet) {
+        // Run if the deployment is running, even if there are no changes
+        return deployment.isRunning();
+    }
+
+    protected GitAuthenticationConfigurator createAuthenticationConfigurator(Configuration config,
+                                                                             String repoUrl) throws
+        DeployerConfigurationException {
+        GitAuthenticationConfigurator authConfigurator = null;
+
+        if (repoUrl.matches(GIT_SSH_URL_REGEX)) {
+            String password = ConfigUtils.getStringProperty(config, REMOTE_REPO_PASSWORD_CONFIG_KEY);
+
+            if (StringUtils.isNotEmpty(password)) {
+                logger.debug("SSH username/password authentication will be used to connect to repo {}", repoUrl);
+
+                authConfigurator = new SshUsernamePasswordAuthConfigurator(password);
+            } else {
+                String privateKeyPath = ConfigUtils.getStringProperty(config, REMOTE_REPO_SSH_PRV_KEY_PATH_CONFIG_KEY);
+                String passphrase = ConfigUtils.getStringProperty(config,
+                                                                  REMOTE_REPO_SSH_PRV_KEY_PASSPHRASE_CONFIG_KEY);
+
+                logger.debug("SSH RSA key pair authentication will be used to connect to repo {}", repoUrl);
+
+                SshRsaKeyPairAuthConfigurator keyPairAuthConfigurator = new SshRsaKeyPairAuthConfigurator();
+                keyPairAuthConfigurator.setPrivateKeyPath(privateKeyPath);
+                keyPairAuthConfigurator.setPassphrase(passphrase);
+
+                authConfigurator = keyPairAuthConfigurator;
+            }
+        } else {
+            String username = ConfigUtils.getStringProperty(config, REMOTE_REPO_USERNAME_CONFIG_KEY);
+            String password = ConfigUtils.getStringProperty(config, REMOTE_REPO_PASSWORD_CONFIG_KEY);
+
+            if (StringUtils.isNotEmpty(username) && StringUtils.isNotEmpty(password)) {
+                logger.debug("Username/password authentication will be used to connect to repo {}", repoUrl);
+
+                authConfigurator = new BasicUsernamePasswordAuthConfigurator(username, password);
+            }
+        }
+
+        return authConfigurator;
+    }
+
+    protected Git openLocalRepository() throws DeployerException {
+        try {
+            logger.debug("Opening local Git repository at {}", localRepoFolder);
+
+            return GitUtils.openRepository(localRepoFolder);
+        } catch (IOException e) {
+            throw new DeployerException("Failed to open Git repository at " + localRepoFolder, e);
+        }
+    }
+
+}

--- a/src/main/java/org/craftercms/deployer/utils/GitUtils.java
+++ b/src/main/java/org/craftercms/deployer/utils/GitUtils.java
@@ -18,11 +18,7 @@ package org.craftercms.deployer.utils;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 import org.craftercms.commons.git.auth.GitAuthenticationConfigurator;
@@ -31,15 +27,12 @@ import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.PullCommand;
 import org.eclipse.jgit.api.PullResult;
 import org.eclipse.jgit.api.PushCommand;
-import org.eclipse.jgit.api.RemoteAddCommand;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.lib.Constants;
-import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.StoredConfig;
 import org.eclipse.jgit.merge.MergeStrategy;
 import org.eclipse.jgit.transport.PushResult;
 import org.eclipse.jgit.transport.RefSpec;
-import org.eclipse.jgit.transport.URIish;
 
 /**
  * Utility methods for Git operations.

--- a/src/main/java/org/craftercms/deployer/utils/GitUtils.java
+++ b/src/main/java/org/craftercms/deployer/utils/GitUtils.java
@@ -18,7 +18,11 @@ package org.craftercms.deployer.utils;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 import org.craftercms.commons.git.auth.GitAuthenticationConfigurator;
@@ -27,11 +31,15 @@ import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.PullCommand;
 import org.eclipse.jgit.api.PullResult;
 import org.eclipse.jgit.api.PushCommand;
+import org.eclipse.jgit.api.RemoteAddCommand;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.lib.Constants;
+import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.StoredConfig;
 import org.eclipse.jgit.merge.MergeStrategy;
 import org.eclipse.jgit.transport.PushResult;
+import org.eclipse.jgit.transport.RefSpec;
+import org.eclipse.jgit.transport.URIish;
 
 /**
  * Utility methods for Git operations.
@@ -39,6 +47,8 @@ import org.eclipse.jgit.transport.PushResult;
  * @author avasquez
  */
 public abstract class GitUtils {
+
+    public static final String GIT_FOLDER_NAME = ".git";
 
     public static final String CORE_CONFIG_SECTION = "core";
     public static final String BIG_FILE_THRESHOLD_CONFIG_PARAM = "bigFileThreshold";
@@ -149,19 +159,19 @@ public abstract class GitUtils {
      *
      * @param git              the Git instance used to handle the repository
      * @param remote           remote name or URL
-     * @param pushAll          if <code>true</code>, pushes all branches
+     * @param branch     the remote branch being pushed to
      * @param authConfigurator the {@link GitAuthenticationConfigurator} class used to configure the authentication
      *                         with the remote
      *                         repository
      * @return the result of the push
      * @throws GitAPIException if a Git related error occurs
      */
-    public static Iterable<PushResult> push(Git git, String remote, boolean pushAll,
+    public static Iterable<PushResult> push(Git git, String remote, String branch,
                                             GitAuthenticationConfigurator authConfigurator) throws GitAPIException {
         PushCommand push = git.push();
         push.setRemote(remote);
-        if (pushAll) {
-            push.setPushAll();
+        if (StringUtils.isNotEmpty(branch)) {
+            push.setRefSpecs(new RefSpec(Constants.HEAD + ":" + Constants.R_HEADS + branch));
         }
 
         if (authConfigurator != null) {


### PR DESCRIPTION
* Added RemoteGitRepoAwareProcessor, which is now the base class for GitPullProcessor and GitPushProcessor.
* Refactored GitPushProcessor to now print the result of the push and receive an optional branch to push.
* Push all was also removed since it might push to origin (which is the published folder in most cases), which we want to avoid.