### PR TITLE
Changes for deployment events:

### DIFF
--- a/src/main/java/org/craftercms/deployer/api/ChangeSet.java
+++ b/src/main/java/org/craftercms/deployer/api/ChangeSet.java
@@ -54,7 +54,27 @@ public class ChangeSet extends AbstractUpdateDetailProvider {
      */
     @JsonProperty("created_files")
     public List<String> getCreatedFiles() {
-        return Collections.unmodifiableList(createdFiles);
+        return createdFiles;
+    }
+
+    /**
+     * Adds a file to the list of created files if it's not in the list
+     * 
+     * @param file the file to add
+     */
+    public void addCreatedFile(String file) {
+        if (!createdFiles.contains(file)) {
+            createdFiles.add(file);
+        }
+    }
+
+    /**
+     * Removes a file from the list of created files.
+     * 
+     * @param file the file to remove
+     */
+    public void removeCreatedFile(String file) {
+        createdFiles.remove(file);
     }
 
     /**
@@ -62,16 +82,56 @@ public class ChangeSet extends AbstractUpdateDetailProvider {
      */
     @JsonProperty("updated_files")
     public List<String> getUpdatedFiles() {
-        return Collections.unmodifiableList(updatedFiles);
+        return updatedFiles;
     }
+
+    /**
+     * Adds a file to the list of updated files if it's not in the list
+     *
+     * @param file the file to add
+     */
+    public void addUpdatedFile(String file) {
+        if (!updatedFiles.contains(file)) {
+            updatedFiles.add(file);
+        }
+    }
+
+    /**
+     * Removes a file from the list of updated files.
+     *
+     * @param file the file to remove
+     */
+    public void removeUpdatedFile(String file) {
+        updatedFiles.remove(file);
+    }    
 
     /**
      * Returns the list of deleted files.
      */
     @JsonProperty("deleted_files")
     public List<String> getDeletedFiles() {
-        return Collections.unmodifiableList(deletedFiles);
+        return deletedFiles;
     }
+
+    /**
+     * Adds a file to the list of deleted files if it's not in the list
+     *
+     * @param file the file to add
+     */
+    public void addDeletedFile(String file) {
+        if (!deletedFiles.contains(file)) {
+            deletedFiles.add(file);
+        }
+    }
+
+    /**
+     * Removes a file from the list of deleted files.
+     *
+     * @param file the file to remove
+     */
+    public void removeDeletedFile(String file) {
+        deletedFiles.remove(file);
+    }    
 
     /**
      * Returns true if there are not created, updated or deleted files.

--- a/src/main/java/org/craftercms/deployer/api/DeploymentProcessor.java
+++ b/src/main/java/org/craftercms/deployer/api/DeploymentProcessor.java
@@ -28,6 +28,11 @@ import org.craftercms.deployer.api.exceptions.DeployerException;
 public interface DeploymentProcessor {
 
     /**
+     * Returns true if this processor runs after the deployment has finalized.
+     */
+    boolean isPostDeployment();
+
+    /**
      * Initializes the processor, configuring it by using the specified configuration.
      *
      * @param config    the processor configuration

--- a/src/main/java/org/craftercms/deployer/impl/DeploymentPipelineFactory.java
+++ b/src/main/java/org/craftercms/deployer/impl/DeploymentPipelineFactory.java
@@ -17,6 +17,7 @@
 package org.craftercms.deployer.impl;
 
 import org.apache.commons.configuration2.HierarchicalConfiguration;
+import org.apache.commons.configuration2.tree.ImmutableNode;
 import org.craftercms.commons.config.ConfigurationException;
 import org.craftercms.deployer.api.DeploymentPipeline;
 import org.craftercms.deployer.api.exceptions.DeployerException;
@@ -42,7 +43,8 @@ public interface DeploymentPipelineFactory {
      * @throws ConfigurationException if a configuration related exception occurs
      * @throws DeployerException if a general error occurs
      */
-    DeploymentPipeline getPipeline(HierarchicalConfiguration configuration, ApplicationContext applicationContext,
-                                   String pipelinePropertyName) throws ConfigurationException, DeployerException;
+    DeploymentPipeline getPipeline(HierarchicalConfiguration<ImmutableNode> configuration,
+                                   ApplicationContext applicationContext, String pipelinePropertyName)
+            throws ConfigurationException, DeployerException;
 
 }

--- a/src/main/java/org/craftercms/deployer/impl/DeploymentPipelineFactoryImpl.java
+++ b/src/main/java/org/craftercms/deployer/impl/DeploymentPipelineFactoryImpl.java
@@ -22,7 +22,6 @@ import org.craftercms.commons.config.ConfigurationException;
 import org.craftercms.deployer.api.DeploymentPipeline;
 import org.craftercms.deployer.api.DeploymentProcessor;
 import org.craftercms.deployer.api.exceptions.DeployerException;
-import org.craftercms.deployer.impl.processors.AbstractMainDeploymentProcessor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;

--- a/src/main/java/org/craftercms/deployer/impl/processors/AbstractMainDeploymentProcessor.java
+++ b/src/main/java/org/craftercms/deployer/impl/processors/AbstractMainDeploymentProcessor.java
@@ -16,6 +16,7 @@
  */
 package org.craftercms.deployer.impl.processors;
 
+import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.lang3.ArrayUtils;
 import org.craftercms.commons.config.ConfigurationException;
@@ -34,10 +35,10 @@ import java.util.List;
 import static org.craftercms.deployer.utils.ConfigUtils.getStringArrayProperty;
 
 /**
- * Base class for {@link org.craftercms.deployer.api.DeploymentProcessor}s that are executed during the main deployment phase, which is
- * the phase where the change set is retrieved and the files are processed. Inclusion/exclusion of files is handled by this class, through
- * YAML configuration properties {@code includeFiles} and {@code excludeFiles}. So basically each processor instance can have its own
- * set of inclusions/exclusions.
+ * Base class for {@link org.craftercms.deployer.api.DeploymentProcessor}s that are executed during the main
+ * deployment phase, which is the phase where the change set is retrieved and the files are processed.
+ * Inclusion/exclusion of files is handled by this class, through YAML configuration properties {@code includeFiles}
+ * and {@code excludeFiles}. So basically each processor instance can have its own set of inclusions/exclusions.
  *
  * @author avasquez
  */
@@ -47,6 +48,11 @@ public abstract class AbstractMainDeploymentProcessor extends AbstractDeployment
 
     protected String[] includeFiles;
     protected String[] excludeFiles;
+
+    @Override
+    public boolean isPostDeployment() {
+        return false;
+    }
 
     @Override
     public void init(Configuration config) throws ConfigurationException, DeployerException {
@@ -60,17 +66,18 @@ public abstract class AbstractMainDeploymentProcessor extends AbstractDeployment
     public void execute(Deployment deployment) {
         ProcessorExecution execution = new ProcessorExecution(name);
         try {
-            ChangeSet filteredChangeSet = getFilteredChangeSet(deployment.getChangeSet());
+            ChangeSet originalChangeSet = deployment.getChangeSet();
+            ChangeSet filteredChangeSet = getFilteredChangeSet(originalChangeSet);
 
             if (shouldExecute(deployment, filteredChangeSet)) {
                 deployment.addProcessorExecution(execution);
 
                 logger.info("----- < {} @ {} > -----", name, targetId);
 
-                ChangeSet processedChangeSet = doExecute(deployment, execution, filteredChangeSet);
+                ChangeSet newChangeSet = doExecute(deployment, execution, filteredChangeSet, originalChangeSet);
 
-                if (processedChangeSet != null) {
-                    deployment.setChangeSet(processedChangeSet);
+                if (newChangeSet != null) {
+                    deployment.setChangeSet(newChangeSet);
                 }
 
                 execution.endExecution(Deployment.Status.SUCCESS);
@@ -114,6 +121,7 @@ public abstract class AbstractMainDeploymentProcessor extends AbstractDeployment
             ChangeSet filteredChangeSet = new ChangeSet(matchedCreatedFiles, matchedUpdatedFiles, matchedDeletedFiles);
             filteredChangeSet.setUpdateDetails(changeSet.getUpdateDetails());
             filteredChangeSet.setUpdateLog(changeSet.getUpdateLog());
+
             return filteredChangeSet;
         } else {
             return changeSet;
@@ -133,7 +141,8 @@ public abstract class AbstractMainDeploymentProcessor extends AbstractDeployment
     protected abstract void doInit(Configuration config) throws ConfigurationException, DeployerException;
 
     protected abstract ChangeSet doExecute(Deployment deployment, ProcessorExecution execution,
-                                           ChangeSet filteredChangeSet) throws DeployerException;
+                                           ChangeSet filteredChangeSet, ChangeSet originalChangeSet)
+            throws DeployerException;
 
     protected abstract boolean failDeploymentOnProcessorFailure();
 

--- a/src/main/java/org/craftercms/deployer/impl/processors/AbstractMainDeploymentProcessor.java
+++ b/src/main/java/org/craftercms/deployer/impl/processors/AbstractMainDeploymentProcessor.java
@@ -16,7 +16,6 @@
  */
 package org.craftercms.deployer.impl.processors;
 
-import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.lang3.ArrayUtils;
 import org.craftercms.commons.config.ConfigurationException;

--- a/src/main/java/org/craftercms/deployer/impl/processors/AbstractPostDeploymentProcessor.java
+++ b/src/main/java/org/craftercms/deployer/impl/processors/AbstractPostDeploymentProcessor.java
@@ -22,14 +22,19 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Base class for {@link org.craftercms.deployer.api.DeploymentProcessor}s that are executed during the post deployment phase, which is
- * the phase that happens after all the files from the change set have been processed.
+ * Base class for {@link org.craftercms.deployer.api.DeploymentProcessor}s that are executed during the post
+ * deployment phase, which is the phase that happens after all the files from the change set have been processed.
  *
  * @author avasquez
  */
 public abstract class AbstractPostDeploymentProcessor extends AbstractDeploymentProcessor {
 
     private static final Logger logger = LoggerFactory.getLogger(AbstractPostDeploymentProcessor.class);
+
+    @Override
+    public boolean isPostDeployment() {
+        return true;
+    }
 
     @Override
     public void execute(Deployment deployment) {

--- a/src/main/java/org/craftercms/deployer/impl/processors/AbstractSearchIndexingProcessor.java
+++ b/src/main/java/org/craftercms/deployer/impl/processors/AbstractSearchIndexingProcessor.java
@@ -219,7 +219,7 @@ public abstract class AbstractSearchIndexingProcessor extends AbstractMainDeploy
 
     @Override
     protected ChangeSet doExecute(Deployment deployment, ProcessorExecution execution,
-                                  ChangeSet filteredChangeSet) throws DeployerException {
+                                  ChangeSet filteredChangeSet, ChangeSet originalChangeSet) throws DeployerException {
         logger.info("Performing search indexing...");
 
         List<String> createdFiles = ListUtils.emptyIfNull(filteredChangeSet.getCreatedFiles());

--- a/src/main/java/org/craftercms/deployer/impl/processors/CommandLineProcessor.java
+++ b/src/main/java/org/craftercms/deployer/impl/processors/CommandLineProcessor.java
@@ -67,7 +67,7 @@ public class CommandLineProcessor extends AbstractMainDeploymentProcessor {
 
     @Override
     protected ChangeSet doExecute(Deployment deployment, ProcessorExecution execution,
-                                  ChangeSet filteredChangeSet) throws DeployerException {
+                                  ChangeSet filteredChangeSet, ChangeSet originalChangeSet) throws DeployerException {
         ProcessBuilder processBuilder = new ProcessBuilder(command.split("\\s"));
 
         if (StringUtils.isNotEmpty(workingDir)) {

--- a/src/main/java/org/craftercms/deployer/impl/processors/DelayProcessor.java
+++ b/src/main/java/org/craftercms/deployer/impl/processors/DelayProcessor.java
@@ -58,8 +58,8 @@ public class DelayProcessor extends AbstractMainDeploymentProcessor {
      * {@inheritDoc}
      */
     @Override
-    protected ChangeSet doExecute(final Deployment deployment, final ProcessorExecution execution,
-                                  final ChangeSet filteredChangeSet) {
+    protected ChangeSet doExecute(Deployment deployment, ProcessorExecution execution,
+                                  ChangeSet filteredChangeSet, ChangeSet originalChangeSet) {
 
         logger.info("Delaying pipeline execution for {} seconds", seconds);
 

--- a/src/main/java/org/craftercms/deployer/impl/processors/FileBasedDeploymentEventProcessor.java
+++ b/src/main/java/org/craftercms/deployer/impl/processors/FileBasedDeploymentEventProcessor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2007-2019 Crafter Software Corporation. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.craftercms.deployer.impl.processors;
 
 import org.apache.commons.configuration2.Configuration;

--- a/src/main/java/org/craftercms/deployer/impl/processors/FileBasedDeploymentEventProcessor.java
+++ b/src/main/java/org/craftercms/deployer/impl/processors/FileBasedDeploymentEventProcessor.java
@@ -117,7 +117,7 @@ public class FileBasedDeploymentEventProcessor extends AbstractMainDeploymentPro
 
     @Override
     public void destroy() throws DeployerException {
-
+        // Nothing to do
     }
 
 }

--- a/src/main/java/org/craftercms/deployer/impl/processors/FileBasedDeploymentEventProcessor.java
+++ b/src/main/java/org/craftercms/deployer/impl/processors/FileBasedDeploymentEventProcessor.java
@@ -1,0 +1,123 @@
+package org.craftercms.deployer.impl.processors;
+
+import org.apache.commons.configuration2.Configuration;
+import org.craftercms.commons.config.ConfigurationException;
+import org.craftercms.deployer.api.ChangeSet;
+import org.craftercms.deployer.api.Deployment;
+import org.craftercms.deployer.api.ProcessorExecution;
+import org.craftercms.deployer.api.exceptions.DeployerException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Required;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Properties;
+
+import static org.craftercms.deployer.utils.ConfigUtils.*;
+
+/**
+ * Triggers a deployment event that consumers of the repository (Crafter Engines) can subscribe to by reading a file
+ * written by this processor.
+ *
+ * @author avasquez
+ */
+public class FileBasedDeploymentEventProcessor extends AbstractMainDeploymentProcessor {
+
+    private static final Logger logger = LoggerFactory.getLogger(FileBasedDeploymentEventProcessor.class);
+
+    private static final String DEFAULT_DEPLOYMENT_EVENTS_FILE_URL= "deployment-events.properties";
+
+    public static final String CONFIG_KEY_DEPLOYMENT_EVENTS_FILE_URL = "deploymentEventsFileUrl";
+    public static final String CONFIG_KEY_EVENT_NAME = "eventName";
+
+    /**
+     * URL for the local git repository.
+     */
+    protected String localRepoUrl;
+
+    /**
+     * URL of the deployment events file, relative to the local git repo.
+     */
+    protected String deploymentEventsFileUrl;
+
+    /**
+     * Name of the event to trigger when this processor runs.
+     */
+    protected String eventName;
+
+    @Required
+    public void setLocalRepoUrl(final String localRepoUrl) {
+        this.localRepoUrl = localRepoUrl;
+    }
+
+    @Override
+    protected void doInit(Configuration config) throws ConfigurationException, DeployerException {
+        deploymentEventsFileUrl = getStringProperty(config, CONFIG_KEY_DEPLOYMENT_EVENTS_FILE_URL,
+                                                    DEFAULT_DEPLOYMENT_EVENTS_FILE_URL);
+        eventName = getRequiredStringProperty(config, CONFIG_KEY_EVENT_NAME);
+    }
+
+    @Override
+    protected ChangeSet doExecute(Deployment deployment, ProcessorExecution execution,
+                                  ChangeSet filteredChangeSet, ChangeSet originalChangeSet) throws DeployerException {
+        Path deploymentEventsPath = Paths.get(localRepoUrl, deploymentEventsFileUrl);
+        Properties deploymentEvents = loadDeploymentEvents(deploymentEventsPath);
+        boolean newFile = deploymentEvents.isEmpty();
+        String now = Instant.now().toString();
+
+        deploymentEvents.setProperty(eventName, now);
+
+        saveDeploymentEvents(deploymentEventsPath, deploymentEvents);
+
+        logger.info("Event {}={} saved to {}", eventName, now, deploymentEventsFileUrl);
+
+        if (newFile) {
+            originalChangeSet.addCreatedFile(deploymentEventsFileUrl);
+        } else {
+            originalChangeSet.addUpdatedFile(deploymentEventsFileUrl);
+        }
+
+        return originalChangeSet;
+    }
+
+    private Properties loadDeploymentEvents(Path deploymentEventsPath) throws DeployerException {
+        Properties deploymentEvents = new Properties();
+
+        if (Files.exists(deploymentEventsPath)) {
+            try (Reader reader = Files.newBufferedReader(deploymentEventsPath, StandardCharsets.UTF_8)) {
+                deploymentEvents.load(reader);
+            } catch (IOException e) {
+                throw new DeployerException("Error reading loading events file @ " + deploymentEventsPath);
+            }
+        }
+
+        return deploymentEvents;
+    }
+
+    private void saveDeploymentEvents(Path deploymentEventsPath, Properties deploymentEvents) throws DeployerException {
+        try (Writer writer = Files.newBufferedWriter(deploymentEventsPath, StandardCharsets.UTF_8)) {
+            deploymentEvents.store(writer, null);
+        } catch (IOException e) {
+            throw new DeployerException("Error saving deployment events file @ " + deploymentEventsPath);
+        }
+    }
+
+    @Override
+    protected boolean failDeploymentOnProcessorFailure() {
+        return false;
+    }
+
+    @Override
+    public void destroy() throws DeployerException {
+
+    }
+
+}

--- a/src/main/java/org/craftercms/deployer/impl/processors/FileBasedDeploymentEventProcessor.java
+++ b/src/main/java/org/craftercms/deployer/impl/processors/FileBasedDeploymentEventProcessor.java
@@ -18,10 +18,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;
-import java.util.Collections;
 import java.util.Properties;
 
-import static org.craftercms.deployer.utils.ConfigUtils.*;
+import static org.craftercms.deployer.utils.ConfigUtils.getRequiredStringProperty;
+import static org.craftercms.deployer.utils.ConfigUtils.getStringProperty;
 
 /**
  * Triggers a deployment event that consumers of the repository (Crafter Engines) can subscribe to by reading a file

--- a/src/main/java/org/craftercms/deployer/impl/processors/FindAndReplaceProcessor.java
+++ b/src/main/java/org/craftercms/deployer/impl/processors/FindAndReplaceProcessor.java
@@ -90,9 +90,8 @@ public class FindAndReplaceProcessor extends AbstractMainDeploymentProcessor {
      * {@inheritDoc}
      */
     @Override
-    protected ChangeSet doExecute(final Deployment deployment, final ProcessorExecution execution,
-                                  final ChangeSet filteredChangeSet) throws DeployerException {
-
+    protected ChangeSet doExecute(Deployment deployment, ProcessorExecution execution,
+                                  ChangeSet filteredChangeSet, ChangeSet originalChangeSet) throws DeployerException {
         logger.info("Performing find and replace...");
         logger.debug("Pattern '{}' will be replaced with '{}'", textPattern, replacement);
 

--- a/src/main/java/org/craftercms/deployer/impl/processors/GitPullProcessor.java
+++ b/src/main/java/org/craftercms/deployer/impl/processors/GitPullProcessor.java
@@ -81,7 +81,7 @@ public class GitPullProcessor extends AbstractRemoteGitRepoAwareProcessor {
 
     @Override
     protected ChangeSet doExecute(Deployment deployment, ProcessorExecution execution,
-                                  ChangeSet filteredChangeSet) throws DeployerException {
+                                  ChangeSet filteredChangeSet, ChangeSet originalChangeSet) throws DeployerException {
         File gitFolder = new File(localRepoFolder, GitUtils.GIT_FOLDER_NAME);
 
         if (localRepoFolder.exists() && gitFolder.exists()) {

--- a/src/main/java/org/craftercms/deployer/impl/processors/GitPushProcessor.java
+++ b/src/main/java/org/craftercms/deployer/impl/processors/GitPushProcessor.java
@@ -62,7 +62,7 @@ public class GitPushProcessor extends AbstractRemoteGitRepoAwareProcessor {
 
     @Override
     protected ChangeSet doExecute(Deployment deployment, ProcessorExecution execution,
-                                  ChangeSet filteredChangeSet) throws DeployerException {
+                                  ChangeSet filteredChangeSet, ChangeSet originalChangeSet) throws DeployerException {
         File gitFolder = new File(localRepoFolder, GitUtils.GIT_FOLDER_NAME);
 
         if (localRepoFolder.exists() && gitFolder.exists()) {

--- a/src/main/java/org/craftercms/deployer/impl/processors/HttpMethodCallProcessor.java
+++ b/src/main/java/org/craftercms/deployer/impl/processors/HttpMethodCallProcessor.java
@@ -71,7 +71,7 @@ public class HttpMethodCallProcessor extends AbstractMainDeploymentProcessor {
 
     @Override
     protected ChangeSet doExecute(Deployment deployment, ProcessorExecution execution,
-                                  ChangeSet filteredChangeSet) throws DeployerException {
+                                  ChangeSet filteredChangeSet, ChangeSet originalChangeSet) throws DeployerException {
         HttpUriRequest request = createRequest();
 
         logger.info("Executing request {}...", request);

--- a/src/main/java/org/craftercms/deployer/impl/processors/aws/AbstractAwsDeploymentProcessor.java
+++ b/src/main/java/org/craftercms/deployer/impl/processors/aws/AbstractAwsDeploymentProcessor.java
@@ -70,10 +70,10 @@ public abstract class AbstractAwsDeploymentProcessor<B extends AwsClientBuilder,
     @Override
     public void init(final Configuration config) throws ConfigurationException, DeployerException {
         super.init(config);
-        if(config.containsKey(CONFIG_KEY_REGION)) {
+        if (config.containsKey(CONFIG_KEY_REGION)) {
             region = getStringProperty(config, CONFIG_KEY_REGION);
         }
-        if(config.containsKey(CONFIG_KEY_ACCESS_KEY) && config.containsKey(CONFIG_KEY_SECRET_KEY)) {
+        if (config.containsKey(CONFIG_KEY_ACCESS_KEY) && config.containsKey(CONFIG_KEY_SECRET_KEY)) {
             accessKey = getStringProperty(config, CONFIG_KEY_ACCESS_KEY);
             secretKey = getStringProperty(config, CONFIG_KEY_SECRET_KEY);
         }
@@ -84,10 +84,10 @@ public abstract class AbstractAwsDeploymentProcessor<B extends AwsClientBuilder,
      * @param builder the client builder
      */
     protected void setCredentials(AwsClientBuilder builder) {
-        if(StringUtils.isNotEmpty(region)) {
+        if (StringUtils.isNotEmpty(region)) {
             builder.withRegion(region);
         }
-        if(StringUtils.isNotEmpty(accessKey) && StringUtils.isNotEmpty(secretKey)) {
+        if (StringUtils.isNotEmpty(accessKey) && StringUtils.isNotEmpty(secretKey)) {
             builder.withCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials(accessKey, secretKey)));
         }
     }

--- a/src/main/java/org/craftercms/deployer/impl/processors/aws/CloudfrontInvalidationProcessor.java
+++ b/src/main/java/org/craftercms/deployer/impl/processors/aws/CloudfrontInvalidationProcessor.java
@@ -75,8 +75,8 @@ public class CloudfrontInvalidationProcessor extends
      */
     @Override
     @SuppressWarnings("unchecked")
-    protected ChangeSet doExecute(final Deployment deployment, final ProcessorExecution execution,
-                                  final ChangeSet filteredChangeSet) throws DeployerException {
+    protected ChangeSet doExecute(Deployment deployment, ProcessorExecution execution,
+                                  ChangeSet filteredChangeSet, ChangeSet originalChangeSet) throws DeployerException {
 
         logger.info("Performing Cloudfront invalidation...");
 
@@ -96,7 +96,7 @@ public class CloudfrontInvalidationProcessor extends
                 CreateInvalidationRequest request = new CreateInvalidationRequest(distribution, batch);
                 CreateInvalidationResult result = client.createInvalidation(request);
                 logger.info("Created invalidation {} for distribution {}",
-                    result.getInvalidation().getId(), distribution);
+                            result.getInvalidation().getId(), distribution);
             } catch (Exception e) {
                 logger.error("Error invalidating changed files for distribution " + distribution, e);
                 throw new DeployerException("Error invalidating changed files for distribution " + distribution, e);

--- a/src/main/java/org/craftercms/deployer/impl/processors/aws/S3SyncProcessor.java
+++ b/src/main/java/org/craftercms/deployer/impl/processors/aws/S3SyncProcessor.java
@@ -90,8 +90,8 @@ public class S3SyncProcessor extends AbstractAwsDeploymentProcessor<AmazonS3Clie
      * {@inheritDoc}
      */
     @Override
-    protected ChangeSet doExecute(final Deployment deployment, final ProcessorExecution execution,
-                                  final ChangeSet filteredChangeSet) throws DeployerException {
+    protected ChangeSet doExecute(Deployment deployment, ProcessorExecution execution,
+                                  ChangeSet filteredChangeSet, ChangeSet originalChangeSet) throws DeployerException {
         logger.info("Performing S3 sync...");
         logger.debug("Syncing with bucket {}", s3Url);
 

--- a/src/main/resources/base-target-context.xml
+++ b/src/main/resources/base-target-context.xml
@@ -267,6 +267,12 @@
         <property name="localRepoUrl" value="${target.localRepoPath}"/>
     </bean>
 
+    <bean id="fileBasedDeploymentEventProcessor"
+          class="org.craftercms.deployer.impl.processors.FileBasedDeploymentEventProcessor"
+          parent="deploymentProcessor">
+        <property name="localRepoUrl" value="${target.localRepoPath}"/>
+    </bean>
+
     <bean id="delayProcessor" parent="deploymentProcessor"
           class="org.craftercms.deployer.impl.processors.DelayProcessor"/>
 

--- a/src/main/resources/templates/targets/aws-s3-target-template.yaml
+++ b/src/main/resources/templates/targets/aws-s3-target-template.yaml
@@ -21,6 +21,7 @@ target:
        enabled: false
     {{/if}}
     pipeline:
+      # -------------------- START OF MAIN PIPELINE --------------------
       - processorName: gitPullProcessor
         remoteRepo:
           url: {{repo_url}}
@@ -50,7 +51,6 @@ target:
       {{/if}}
       - processorName: {{#if use_crafter_search}}searchIndexingProcessor{{else}}elasticSearchIndexingProcessor{{/if}}
       - processorName: s3SyncProcessor
-        excludeFiles: ['^/config/studio/.*$']
         region: ${aws.region}
         accessKey: ${aws.accessKey}
         secretKey: ${aws.secretKey}
@@ -68,18 +68,19 @@ target:
           - {{this}}
         {{/list}}
       {{/if}}
-      {{#if engine_urls}}
-      {{#list engine_urls}}
-      - processorName: httpMethodCallProcessor
+      - processorName: fileBasedDeploymentEventProcessor
         includeFiles: ["^/?config/engine/.*$", "^/?scripts/.*$"]
-        method: GET
-        url: {{this}}/api/1/site/context/rebuild.json?crafterSite=${target.siteName}
-      - processorName: httpMethodCallProcessor
+        eventName: 'events.deployment.rebuildContext'
+      - processorName: fileBasedDeploymentEventProcessor
         excludeFiles: ['^/static-assets/.*$']
-        method: GET
-        url: {{this}}/api/1/site/cache/clear.json?crafterSite=${target.siteName}
-      {{/list}}
-      {{/if}}
+        eventName: 'events.deployment.clearCache'
+      - processorName: s3SyncProcessor
+        includeFiles: ['^/?deployment-events\.properties$']
+        region: ${aws.region}
+        accessKey: ${aws.accessKey}
+        secretKey: ${aws.secretKey}
+        url: {{aws.s3.url}}
+      # -------------------- END OF MAIN PIPELINE --------------------
       - processorName: fileOutputProcessor
       {{#if notification_addresses}}
       - processorName: mailNotificationProcessor

--- a/src/test/java/org/craftercms/deployer/test/utils/TestDeploymentProcessor.java
+++ b/src/test/java/org/craftercms/deployer/test/utils/TestDeploymentProcessor.java
@@ -55,7 +55,7 @@ public class TestDeploymentProcessor extends AbstractMainDeploymentProcessor {
 
     @Override
     protected ChangeSet doExecute(Deployment deployment, ProcessorExecution execution,
-                                  ChangeSet filteredChangeSet) throws DeployerException {
+                                  ChangeSet filteredChangeSet, ChangeSet originalChangeSet) {
         logger.info("Test deployment processor running");
 
         return filteredChangeSet;


### PR DESCRIPTION
* Added processor that saves cache clear/rebuild context events in a file.
* Added originalChangeSet to list of parameters of AbstractMainDeploymentProcessor.doExecute so processors can modify the change set of the deployment.

Ticket craftercms/craftercms#2935
