### PR TITLE
Processor fixes/enhancements:

### DIFF
--- a/src/main/java/org/craftercms/deployer/api/Deployment.java
+++ b/src/main/java/org/craftercms/deployer/api/Deployment.java
@@ -199,6 +199,15 @@ public class Deployment {
         return params.get(name);
     }
 
+    /**
+     * Removes the specified param
+     *
+     * @param name the name of the param
+     */
+    public void removeParam(String name) {
+        params.remove(name);
+    }
+
     public enum Status {
         SUCCESS, FAILURE
     }

--- a/src/main/java/org/craftercms/deployer/impl/DeploymentConstants.java
+++ b/src/main/java/org/craftercms/deployer/impl/DeploymentConstants.java
@@ -38,6 +38,8 @@ public abstract class DeploymentConstants {
     // Processor-specific Configuration Keys
 
     public static final String PROCESSOR_NAME_CONFIG_KEY = "processorName";
+    public static final String PROCESSOR_LABEL_CONFIG_KEY = "processorLabel";
+    public static final String PROCESSOR_JUMP_TO_CONFIG_KEY = "jumpTo";
     public static final String PROCESSOR_INCLUDE_FILES_CONFIG_KEY = "includeFiles";
     public static final String PROCESSOR_EXCLUDE_FILES_CONFIG_KEY = "excludeFiles";
 

--- a/src/main/java/org/craftercms/deployer/impl/processors/AbstractDeploymentProcessor.java
+++ b/src/main/java/org/craftercms/deployer/impl/processors/AbstractDeploymentProcessor.java
@@ -16,22 +16,56 @@
  */
 package org.craftercms.deployer.impl.processors;
 
+import org.apache.commons.configuration2.Configuration;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.craftercms.commons.config.ConfigurationException;
+import org.craftercms.commons.lang.RegexUtils;
+import org.craftercms.deployer.api.ChangeSet;
+import org.craftercms.deployer.api.Deployment;
 import org.craftercms.deployer.api.DeploymentProcessor;
+import org.craftercms.deployer.api.exceptions.DeployerException;
+import org.craftercms.deployer.impl.DeploymentConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.BeanNameAware;
 import org.springframework.beans.factory.annotation.Required;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.craftercms.commons.config.ConfigUtils.getStringProperty;
+import static org.craftercms.deployer.utils.ConfigUtils.getStringArrayProperty;
+
 /**
- * Base class for all {@link DeploymentProcessor}s. All processor are expected to be configured as prototypes in Spring, so it's
- * possible to have processor instances per target, and inject target specific properties.
+ * Base class for {@link org.craftercms.deployer.api.DeploymentProcessor}s. Inclusion/exclusion of files is handled
+ * by this class, through YAML configuration properties {@code includeFiles} and {@code excludeFiles}. So basically
+ * each processor instance can have its own set of inclusions/exclusions.
+ *
+ * <p>
+ * This class also handles processor "jumping", which is triggered when a processor explicitly indicates that after
+ * a successful execution the pipeline should skip directly to executing a processor with a certain label.
+ * </p>
  *
  * @author avasquez
  */
-public abstract class AbstractDeploymentProcessor implements DeploymentProcessor, BeanNameAware  {
+public abstract class AbstractDeploymentProcessor implements DeploymentProcessor, BeanNameAware {
+
+    private static final Logger logger = LoggerFactory.getLogger(AbstractDeploymentProcessor.class);
+
+    public static final String JUMPING_TO_PARAM_NAME = "jumping_to";
 
     protected String env;
     protected String siteName;
     protected String targetId;
     protected String name;
+
+    // Config properties (populated on init)
+
+    protected String label;
+    protected String jumpTo;
+    protected String[] includeFiles;
+    protected String[] excludeFiles;
 
     /**
      * Sets the environment of the site.
@@ -64,5 +98,109 @@ public abstract class AbstractDeploymentProcessor implements DeploymentProcessor
     public void setBeanName(String name) {
         this.name = name;
     }
+
+
+    @Override
+    public boolean isPostDeployment() {
+        return false;
+    }
+
+    @Override
+    public void init(Configuration config) throws ConfigurationException, DeployerException {
+        label = getStringProperty(config, DeploymentConstants.PROCESSOR_LABEL_CONFIG_KEY);
+        jumpTo = getStringProperty(config, DeploymentConstants.PROCESSOR_JUMP_TO_CONFIG_KEY);
+        includeFiles = getStringArrayProperty(config, DeploymentConstants.PROCESSOR_INCLUDE_FILES_CONFIG_KEY);
+        excludeFiles = getStringArrayProperty(config, DeploymentConstants.PROCESSOR_EXCLUDE_FILES_CONFIG_KEY);
+
+        doInit(config);
+    }
+
+    @Override
+    public void execute(Deployment deployment) {
+        ChangeSet originalChangeSet = deployment.getChangeSet();
+        ChangeSet filteredChangeSet = getFilteredChangeSet(originalChangeSet);
+
+        if (!isJumpToActive(deployment) && shouldExecute(deployment, filteredChangeSet)) {
+            logger.info("----- < {} @ {} > -----", name, targetId);
+
+            try {
+                ChangeSet newChangeSet = doExecute(deployment, filteredChangeSet, originalChangeSet);
+                if (newChangeSet != null) {
+                    deployment.setChangeSet(newChangeSet);
+                }
+
+                if (StringUtils.isNotEmpty(jumpTo)) {
+                    startJumpTo(deployment);
+                }
+            } catch (Exception e) {
+                logger.error("Processor '" + name + "' for target '" + targetId + "' failed", e);
+            } finally {
+                logger.info("----- </ {} @ {} > -----", name, targetId);
+            }
+        }
+    }
+
+    protected ChangeSet getFilteredChangeSet(ChangeSet changeSet) {
+        if (changeSet != null && (ArrayUtils.isNotEmpty(includeFiles) || ArrayUtils.isNotEmpty(excludeFiles))) {
+            List<String> matchedCreatedFiles = new ArrayList<>();
+            List<String> matchedUpdatedFiles = new ArrayList<>();
+            List<String> matchedDeletedFiles = new ArrayList<>();
+
+            for (String path : changeSet.getCreatedFiles()) {
+                if (shouldIncludeFile(path)) {
+                    matchedCreatedFiles.add(path);
+                }
+            }
+            for (String path : changeSet.getUpdatedFiles()) {
+                if (shouldIncludeFile(path)) {
+                    matchedUpdatedFiles.add(path);
+                }
+            }
+            for (String path : changeSet.getDeletedFiles()) {
+                if (shouldIncludeFile(path)) {
+                    matchedDeletedFiles.add(path);
+                }
+            }
+
+            ChangeSet filteredChangeSet = new ChangeSet(matchedCreatedFiles, matchedUpdatedFiles, matchedDeletedFiles);
+            filteredChangeSet.setUpdateDetails(changeSet.getUpdateDetails());
+            filteredChangeSet.setUpdateLog(changeSet.getUpdateLog());
+
+            return filteredChangeSet;
+        } else {
+            return changeSet;
+        }
+    }
+
+    protected boolean shouldIncludeFile(String file) {
+        return (ArrayUtils.isEmpty(includeFiles) || RegexUtils.matchesAny(file, includeFiles)) &&
+               (ArrayUtils.isEmpty(excludeFiles) || !RegexUtils.matchesAny(file, excludeFiles));
+    }
+
+    protected boolean isJumpToActive(Deployment deployment) {
+        String jumpingTo = (String) deployment.getParam(JUMPING_TO_PARAM_NAME);
+        if (StringUtils.isEmpty(jumpingTo)) {
+            return false;
+        } else if (jumpingTo.equals(label)) {
+            deployment.removeParam(JUMPING_TO_PARAM_NAME);
+
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    protected void startJumpTo(Deployment deployment) {
+        logger.info("Jumping to processor of target '" + targetId + "' with label '" + jumpTo + "'");
+
+        deployment.addParam(JUMPING_TO_PARAM_NAME, jumpTo);
+    }
+
+    protected abstract boolean shouldExecute(Deployment deployment, ChangeSet filteredChangeSet);
+
+    protected abstract void doInit(Configuration config) throws ConfigurationException, DeployerException;
+
+    protected abstract ChangeSet doExecute(Deployment deployment, ChangeSet filteredChangeSet,
+                                           ChangeSet originalChangeSet) throws Exception;
 
 }

--- a/src/main/java/org/craftercms/deployer/impl/processors/AbstractMainDeploymentProcessor.java
+++ b/src/main/java/org/craftercms/deployer/impl/processors/AbstractMainDeploymentProcessor.java
@@ -16,133 +16,54 @@
  */
 package org.craftercms.deployer.impl.processors;
 
-import org.apache.commons.configuration2.Configuration;
-import org.apache.commons.lang3.ArrayUtils;
-import org.craftercms.commons.config.ConfigurationException;
-import org.craftercms.commons.lang.RegexUtils;
 import org.craftercms.deployer.api.ChangeSet;
 import org.craftercms.deployer.api.Deployment;
 import org.craftercms.deployer.api.ProcessorExecution;
 import org.craftercms.deployer.api.exceptions.DeployerException;
-import org.craftercms.deployer.impl.DeploymentConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.craftercms.deployer.utils.ConfigUtils.getStringArrayProperty;
 
 /**
  * Base class for {@link org.craftercms.deployer.api.DeploymentProcessor}s that are executed during the main
  * deployment phase, which is the phase where the change set is retrieved and the files are processed.
- * Inclusion/exclusion of files is handled by this class, through YAML configuration properties {@code includeFiles}
- * and {@code excludeFiles}. So basically each processor instance can have its own set of inclusions/exclusions.
  *
  * @author avasquez
  */
 public abstract class AbstractMainDeploymentProcessor extends AbstractDeploymentProcessor {
 
-    private static final Logger logger = LoggerFactory.getLogger(AbstractMainDeploymentProcessor.class);
-
-    // Config properties (populated on init)
-
-    protected String[] includeFiles;
-    protected String[] excludeFiles;
-
     @Override
-    public boolean isPostDeployment() {
-        return false;
-    }
-
-    @Override
-    public void init(Configuration config) throws ConfigurationException, DeployerException {
-        includeFiles = getStringArrayProperty(config, DeploymentConstants.PROCESSOR_INCLUDE_FILES_CONFIG_KEY);
-        excludeFiles = getStringArrayProperty(config, DeploymentConstants.PROCESSOR_EXCLUDE_FILES_CONFIG_KEY);
-
-        doInit(config);
-    }
-
-    @Override
-    public void execute(Deployment deployment) {
+    protected ChangeSet doExecute(Deployment deployment, ChangeSet filteredChangeSet,
+                                  ChangeSet originalChangeSet) throws Exception {
         ProcessorExecution execution = new ProcessorExecution(name);
+
+        deployment.addProcessorExecution(execution);
+
         try {
-            ChangeSet originalChangeSet = deployment.getChangeSet();
-            ChangeSet filteredChangeSet = getFilteredChangeSet(originalChangeSet);
+            ChangeSet newChangeSet = doMainProcess(deployment, execution, filteredChangeSet, originalChangeSet);
 
-            if (shouldExecute(deployment, filteredChangeSet)) {
-                deployment.addProcessorExecution(execution);
+            execution.endExecution(Deployment.Status.SUCCESS);
 
-                logger.info("----- < {} @ {} > -----", name, targetId);
-
-                ChangeSet newChangeSet = doExecute(deployment, execution, filteredChangeSet, originalChangeSet);
-
-                if (newChangeSet != null) {
-                    deployment.setChangeSet(newChangeSet);
-                }
-
-                execution.endExecution(Deployment.Status.SUCCESS);
-            }
+            return newChangeSet;
         } catch (Exception e) {
-            logger.error("Processor '" + name + "' for target '" + targetId + "' failed", e);
-
             execution.setStatusDetails(e.toString());
             execution.endExecution(Deployment.Status.FAILURE);
 
             if (failDeploymentOnProcessorFailure()) {
                 deployment.end(Deployment.Status.FAILURE);
             }
-        } finally {
-            logger.info("----- </ {} @ {} > -----", name, targetId);
+
+            throw e;
         }
     }
 
-    protected ChangeSet getFilteredChangeSet(ChangeSet changeSet) {
-        if (changeSet != null && (ArrayUtils.isNotEmpty(includeFiles) || ArrayUtils.isNotEmpty(excludeFiles))) {
-            List<String> matchedCreatedFiles = new ArrayList<>();
-            List<String> matchedUpdatedFiles = new ArrayList<>();
-            List<String> matchedDeletedFiles = new ArrayList<>();
-
-            for (String path : changeSet.getCreatedFiles()) {
-                if (shouldIncludeFile(path)) {
-                    matchedCreatedFiles.add(path);
-                }
-            }
-            for (String path : changeSet.getUpdatedFiles()) {
-                if (shouldIncludeFile(path)) {
-                    matchedUpdatedFiles.add(path);
-                }
-            }
-            for (String path : changeSet.getDeletedFiles()) {
-                if (shouldIncludeFile(path)) {
-                    matchedDeletedFiles.add(path);
-                }
-            }
-
-            ChangeSet filteredChangeSet = new ChangeSet(matchedCreatedFiles, matchedUpdatedFiles, matchedDeletedFiles);
-            filteredChangeSet.setUpdateDetails(changeSet.getUpdateDetails());
-            filteredChangeSet.setUpdateLog(changeSet.getUpdateLog());
-
-            return filteredChangeSet;
-        } else {
-            return changeSet;
-        }
-    }
-
-    protected boolean shouldIncludeFile(String file) {
-        return (ArrayUtils.isEmpty(includeFiles) || RegexUtils.matchesAny(file, includeFiles)) &&
-               (ArrayUtils.isEmpty(excludeFiles) || !RegexUtils.matchesAny(file, excludeFiles));
-    }
-
+    @Override
     protected boolean shouldExecute(Deployment deployment, ChangeSet filteredChangeSet) {
         // Run if the deployment is running and change set is not empty
         return deployment.isRunning() && filteredChangeSet != null && !filteredChangeSet.isEmpty();
     }
 
-    protected abstract void doInit(Configuration config) throws ConfigurationException, DeployerException;
-
-    protected abstract ChangeSet doExecute(Deployment deployment, ProcessorExecution execution,
-                                           ChangeSet filteredChangeSet, ChangeSet originalChangeSet)
+    protected abstract ChangeSet doMainProcess(Deployment deployment, ProcessorExecution execution,
+                                               ChangeSet filteredChangeSet, ChangeSet originalChangeSet)
             throws DeployerException;
 
     protected abstract boolean failDeploymentOnProcessorFailure();

--- a/src/main/java/org/craftercms/deployer/impl/processors/AbstractMainDeploymentProcessor.java
+++ b/src/main/java/org/craftercms/deployer/impl/processors/AbstractMainDeploymentProcessor.java
@@ -20,8 +20,6 @@ import org.craftercms.deployer.api.ChangeSet;
 import org.craftercms.deployer.api.Deployment;
 import org.craftercms.deployer.api.ProcessorExecution;
 import org.craftercms.deployer.api.exceptions.DeployerException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Base class for {@link org.craftercms.deployer.api.DeploymentProcessor}s that are executed during the main

--- a/src/main/java/org/craftercms/deployer/impl/processors/AbstractPostDeploymentProcessor.java
+++ b/src/main/java/org/craftercms/deployer/impl/processors/AbstractPostDeploymentProcessor.java
@@ -18,10 +18,7 @@ package org.craftercms.deployer.impl.processors;
 
 import org.craftercms.deployer.api.ChangeSet;
 import org.craftercms.deployer.api.Deployment;
-import org.craftercms.deployer.api.ProcessorExecution;
 import org.craftercms.deployer.api.exceptions.DeployerException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Base class for {@link org.craftercms.deployer.api.DeploymentProcessor}s that are executed during the post

--- a/src/main/java/org/craftercms/deployer/impl/processors/AbstractPostDeploymentProcessor.java
+++ b/src/main/java/org/craftercms/deployer/impl/processors/AbstractPostDeploymentProcessor.java
@@ -16,7 +16,9 @@
  */
 package org.craftercms.deployer.impl.processors;
 
+import org.craftercms.deployer.api.ChangeSet;
 import org.craftercms.deployer.api.Deployment;
+import org.craftercms.deployer.api.ProcessorExecution;
 import org.craftercms.deployer.api.exceptions.DeployerException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,35 +31,26 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class AbstractPostDeploymentProcessor extends AbstractDeploymentProcessor {
 
-    private static final Logger logger = LoggerFactory.getLogger(AbstractPostDeploymentProcessor.class);
-
     @Override
     public boolean isPostDeployment() {
         return true;
     }
 
     @Override
-    public void execute(Deployment deployment) {
+    protected ChangeSet doExecute(Deployment deployment, ChangeSet filteredChangeSet,
+                                  ChangeSet originalChangeSet) throws Exception {
         deployment.end(Deployment.Status.SUCCESS);
 
-        if (shouldExecute(deployment)) {
-            try {
-                logger.info("----- < {} @ {} > -----", name, targetId);
-
-                doExecute(deployment);
-            } catch (Exception e) {
-                logger.error("Processor '" + name + "' for target '" + targetId + "' failed", e);
-            } finally {
-                logger.info("----- </ {} @ {} > -----", name, targetId);
-            }
-        }
+        return doPostProcess(deployment, filteredChangeSet, originalChangeSet);
     }
 
-    protected boolean shouldExecute(Deployment deployment) {
-        // Run if there was a failure or the change set is not empty
+    @Override
+    protected boolean shouldExecute(Deployment deployment, ChangeSet filteredChangeSet) {
+        // Run if there's a current jump to and it matches the label if there was a failure or the change set is not empty
         return deployment.getStatus() == Deployment.Status.FAILURE || !deployment.isChangeSetEmpty();
     }
 
-    protected abstract void doExecute(Deployment deployment) throws DeployerException;
+    protected abstract ChangeSet doPostProcess(Deployment deployment, ChangeSet filteredChangeSet,
+                                               ChangeSet originalChangeSet) throws DeployerException;
 
 }

--- a/src/main/java/org/craftercms/deployer/impl/processors/AbstractSearchIndexingProcessor.java
+++ b/src/main/java/org/craftercms/deployer/impl/processors/AbstractSearchIndexingProcessor.java
@@ -222,8 +222,8 @@ public abstract class AbstractSearchIndexingProcessor extends AbstractMainDeploy
     }
 
     @Override
-    protected ChangeSet doExecute(Deployment deployment, ProcessorExecution execution,
-                                  ChangeSet filteredChangeSet, ChangeSet originalChangeSet) throws DeployerException {
+    protected ChangeSet doMainProcess(Deployment deployment, ProcessorExecution execution,
+                                      ChangeSet filteredChangeSet, ChangeSet originalChangeSet) throws DeployerException {
         logger.info("Performing search indexing...");
 
         List<String> createdFiles = ListUtils.emptyIfNull(filteredChangeSet.getCreatedFiles());

--- a/src/main/java/org/craftercms/deployer/impl/processors/CommandLineProcessor.java
+++ b/src/main/java/org/craftercms/deployer/impl/processors/CommandLineProcessor.java
@@ -68,8 +68,8 @@ public class CommandLineProcessor extends AbstractMainDeploymentProcessor {
     }
 
     @Override
-    protected ChangeSet doExecute(Deployment deployment, ProcessorExecution execution,
-                                  ChangeSet filteredChangeSet, ChangeSet originalChangeSet) throws DeployerException {
+    protected ChangeSet doMainProcess(Deployment deployment, ProcessorExecution execution,
+                                      ChangeSet filteredChangeSet, ChangeSet originalChangeSet) throws DeployerException {
         ProcessBuilder processBuilder = new ProcessBuilder(command.split("\\s"));
 
         if (StringUtils.isNotEmpty(workingDir)) {

--- a/src/main/java/org/craftercms/deployer/impl/processors/DelayProcessor.java
+++ b/src/main/java/org/craftercms/deployer/impl/processors/DelayProcessor.java
@@ -60,8 +60,8 @@ public class DelayProcessor extends AbstractMainDeploymentProcessor {
      * {@inheritDoc}
      */
     @Override
-    protected ChangeSet doExecute(Deployment deployment, ProcessorExecution execution,
-                                  ChangeSet filteredChangeSet, ChangeSet originalChangeSet) {
+    protected ChangeSet doMainProcess(Deployment deployment, ProcessorExecution execution,
+                                      ChangeSet filteredChangeSet, ChangeSet originalChangeSet) {
 
         logger.info("Delaying pipeline execution for {} seconds", seconds);
 

--- a/src/main/java/org/craftercms/deployer/impl/processors/FileBasedDeploymentEventProcessor.java
+++ b/src/main/java/org/craftercms/deployer/impl/processors/FileBasedDeploymentEventProcessor.java
@@ -83,8 +83,8 @@ public class FileBasedDeploymentEventProcessor extends AbstractMainDeploymentPro
     }
 
     @Override
-    protected ChangeSet doExecute(Deployment deployment, ProcessorExecution execution,
-                                  ChangeSet filteredChangeSet, ChangeSet originalChangeSet) throws DeployerException {
+    protected ChangeSet doMainProcess(Deployment deployment, ProcessorExecution execution,
+                                      ChangeSet filteredChangeSet, ChangeSet originalChangeSet) throws DeployerException {
         Path deploymentEventsPath = Paths.get(localRepoUrl, deploymentEventsFileUrl);
         Properties deploymentEvents = loadDeploymentEvents(deploymentEventsPath);
         boolean newFile = deploymentEvents.isEmpty();

--- a/src/main/java/org/craftercms/deployer/impl/processors/FileOutputProcessor.java
+++ b/src/main/java/org/craftercms/deployer/impl/processors/FileOutputProcessor.java
@@ -57,7 +57,7 @@ public class FileOutputProcessor extends AbstractPostDeploymentProcessor {
     }
 
     @Override
-    public void init(Configuration config) throws DeployerException {
+    public void doInit(Configuration config) throws DeployerException {
         if (!outputFolder.exists()) {
             try {
                 FileUtils.forceMkdir(outputFolder);
@@ -72,7 +72,8 @@ public class FileOutputProcessor extends AbstractPostDeploymentProcessor {
     }
 
     @Override
-    protected void doExecute(Deployment deployment) throws DeployerException {
+    protected ChangeSet doPostProcess(Deployment deployment, ChangeSet filteredChangeSet,
+                                      ChangeSet originalChangeSet) throws DeployerException {
         File outputFile = getOutputFile(deployment);
         try (FileWriter fileWriter = new FileWriter(outputFile, true)) {
             CSVPrinter printer;
@@ -100,14 +101,15 @@ public class FileOutputProcessor extends AbstractPostDeploymentProcessor {
         deployment.addParam(OUTPUT_FILE_PARAM_NAME, outputFile);
 
         logger.info("Successfully wrote deployment output to {}", outputFile);
+
+        return null;
     }
 
     protected File getOutputFile(Deployment deployment) {
         String targetId = deployment.getTarget().getId();
         String outputFilename = targetId + "-deployments.csv";
-        File outputFile = new File(outputFolder, outputFilename);
 
-        return outputFile;
+        return new File(outputFolder, outputFilename);
     }
 
 }

--- a/src/main/java/org/craftercms/deployer/impl/processors/FindAndReplaceProcessor.java
+++ b/src/main/java/org/craftercms/deployer/impl/processors/FindAndReplaceProcessor.java
@@ -91,8 +91,8 @@ public class FindAndReplaceProcessor extends AbstractMainDeploymentProcessor {
      * {@inheritDoc}
      */
     @Override
-    protected ChangeSet doExecute(Deployment deployment, ProcessorExecution execution,
-                                  ChangeSet filteredChangeSet, ChangeSet originalChangeSet) throws DeployerException {
+    protected ChangeSet doMainProcess(Deployment deployment, ProcessorExecution execution,
+                                      ChangeSet filteredChangeSet, ChangeSet originalChangeSet) throws DeployerException {
         logger.info("Performing find and replace...");
         logger.debug("Pattern '{}' will be replaced with '{}'", textPattern, replacement);
 

--- a/src/main/java/org/craftercms/deployer/impl/processors/GitDiffProcessor.java
+++ b/src/main/java/org/craftercms/deployer/impl/processors/GitDiffProcessor.java
@@ -110,8 +110,8 @@ public class GitDiffProcessor extends AbstractMainDeploymentProcessor {
     }
 
     @Override
-    protected ChangeSet doExecute(Deployment deployment, ProcessorExecution execution,
-                                  ChangeSet filteredChangeSet, ChangeSet originalChangeSet) throws DeployerException {
+    protected ChangeSet doMainProcess(Deployment deployment, ProcessorExecution execution,
+                                      ChangeSet filteredChangeSet, ChangeSet originalChangeSet) throws DeployerException {
         boolean reprocessAllFiles = getReprocessAllFilesParam(deployment);
         if (reprocessAllFiles) {
             processedCommitsStore.delete(targetId);

--- a/src/main/java/org/craftercms/deployer/impl/processors/GitPullProcessor.java
+++ b/src/main/java/org/craftercms/deployer/impl/processors/GitPullProcessor.java
@@ -82,8 +82,8 @@ public class GitPullProcessor extends AbstractRemoteGitRepoAwareProcessor {
     }
 
     @Override
-    protected ChangeSet doExecute(Deployment deployment, ProcessorExecution execution,
-                                  ChangeSet filteredChangeSet, ChangeSet originalChangeSet) throws DeployerException {
+    protected ChangeSet doMainProcess(Deployment deployment, ProcessorExecution execution,
+                                      ChangeSet filteredChangeSet, ChangeSet originalChangeSet) throws DeployerException {
         File gitFolder = new File(localRepoFolder, GitUtils.GIT_FOLDER_NAME);
 
         if (localRepoFolder.exists() && gitFolder.exists()) {

--- a/src/main/java/org/craftercms/deployer/impl/processors/GitPushProcessor.java
+++ b/src/main/java/org/craftercms/deployer/impl/processors/GitPushProcessor.java
@@ -61,8 +61,8 @@ public class GitPushProcessor extends AbstractRemoteGitRepoAwareProcessor {
     private static final Logger logger = LoggerFactory.getLogger(GitPushProcessor.class);
 
     @Override
-    protected ChangeSet doExecute(Deployment deployment, ProcessorExecution execution,
-                                  ChangeSet filteredChangeSet, ChangeSet originalChangeSet) throws DeployerException {
+    protected ChangeSet doMainProcess(Deployment deployment, ProcessorExecution execution,
+                                      ChangeSet filteredChangeSet, ChangeSet originalChangeSet) throws DeployerException {
         File gitFolder = new File(localRepoFolder, GitUtils.GIT_FOLDER_NAME);
 
         if (localRepoFolder.exists() && gitFolder.exists()) {

--- a/src/main/java/org/craftercms/deployer/impl/processors/HttpMethodCallProcessor.java
+++ b/src/main/java/org/craftercms/deployer/impl/processors/HttpMethodCallProcessor.java
@@ -72,8 +72,8 @@ public class HttpMethodCallProcessor extends AbstractMainDeploymentProcessor {
     }
 
     @Override
-    protected ChangeSet doExecute(Deployment deployment, ProcessorExecution execution,
-                                  ChangeSet filteredChangeSet, ChangeSet originalChangeSet) throws DeployerException {
+    protected ChangeSet doMainProcess(Deployment deployment, ProcessorExecution execution,
+                                      ChangeSet filteredChangeSet, ChangeSet originalChangeSet) throws DeployerException {
         HttpUriRequest request = createRequest();
 
         logger.info("Executing request {}...", request);

--- a/src/main/java/org/craftercms/deployer/impl/processors/aws/CloudfrontInvalidationProcessor.java
+++ b/src/main/java/org/craftercms/deployer/impl/processors/aws/CloudfrontInvalidationProcessor.java
@@ -77,8 +77,8 @@ public class CloudfrontInvalidationProcessor extends
      */
     @Override
     @SuppressWarnings("unchecked")
-    protected ChangeSet doExecute(Deployment deployment, ProcessorExecution execution,
-                                  ChangeSet filteredChangeSet, ChangeSet originalChangeSet) throws DeployerException {
+    protected ChangeSet doMainProcess(Deployment deployment, ProcessorExecution execution,
+                                      ChangeSet filteredChangeSet, ChangeSet originalChangeSet) throws DeployerException {
 
         logger.info("Performing Cloudfront invalidation...");
 

--- a/src/main/java/org/craftercms/deployer/impl/processors/aws/S3SyncProcessor.java
+++ b/src/main/java/org/craftercms/deployer/impl/processors/aws/S3SyncProcessor.java
@@ -92,8 +92,8 @@ public class S3SyncProcessor extends AbstractAwsDeploymentProcessor<AmazonS3Clie
      * {@inheritDoc}
      */
     @Override
-    protected ChangeSet doExecute(Deployment deployment, ProcessorExecution execution,
-                                  ChangeSet filteredChangeSet, ChangeSet originalChangeSet) throws DeployerException {
+    protected ChangeSet doMainProcess(Deployment deployment, ProcessorExecution execution,
+                                      ChangeSet filteredChangeSet, ChangeSet originalChangeSet) throws DeployerException {
         logger.info("Performing S3 sync...");
         logger.debug("Syncing with bucket {}", s3Url);
 

--- a/src/main/resources/templates/targets/local-target-template.yaml
+++ b/src/main/resources/templates/targets/local-target-template.yaml
@@ -18,14 +18,16 @@ target:
         excludeFiles: ["^/?config/studio/content-types.*$"]
         method: GET
         url: ${target.engineUrl}/api/1/site/context/rebuild.json?crafterSite=${target.siteName}
+        jumpTo: fileOutputProcessor
+      - processorName: httpMethodCallProcessor
+        method: GET
+        url: ${target.engineUrl}/api/1/site/cache/clear.json?crafterSite=${target.siteName}
       - processorName: httpMethodCallProcessor
         includeFiles: ["^/?config/studio/content-types.*$"]
         method: GET
         url: ${target.engineUrl}/api/1/site/context/graphql/rebuild.json?crafterSite=${target.siteName}
-      - processorName: httpMethodCallProcessor
-        method: GET
-        url: ${target.engineUrl}/api/1/site/cache/clear.json?crafterSite=${target.siteName}
       - processorName: fileOutputProcessor
+        processorLabel: fileOutputProcessor
       {{#if notification_addresses}}
       - processorName: mailNotificationProcessor
         to:

--- a/src/main/resources/templates/targets/remote-target-template.yaml
+++ b/src/main/resources/templates/targets/remote-target-template.yaml
@@ -35,14 +35,16 @@ target:
         excludeFiles: ["^/?config/studio/content-types.*$"]
         method: GET
         url: ${target.engineUrl}/api/1/site/context/rebuild.json?crafterSite=${target.siteName}
+        jumpTo: fileOutputProcessor
+      - processorName: httpMethodCallProcessor
+        method: GET
+        url: ${target.engineUrl}/api/1/site/cache/clear.json?crafterSite=${target.siteName}
       - processorName: httpMethodCallProcessor
         includeFiles: ["^/?config/studio/content-types.*$"]
         method: GET
         url: ${target.engineUrl}/api/1/site/context/graphql/rebuild.json?crafterSite=${target.siteName}
-      - processorName: httpMethodCallProcessor
-        method: GET
-        url: ${target.engineUrl}/api/1/site/cache/clear.json?crafterSite=${target.siteName}
       - processorName: fileOutputProcessor
+        processorLabel: fileOutputProcessor
       {{#if notification_addresses}}
       - processorName: mailNotificationProcessor
         to:

--- a/src/test/java/org/craftercms/deployer/test/utils/TestDeploymentProcessor.java
+++ b/src/test/java/org/craftercms/deployer/test/utils/TestDeploymentProcessor.java
@@ -54,8 +54,8 @@ public class TestDeploymentProcessor extends AbstractMainDeploymentProcessor {
     }
 
     @Override
-    protected ChangeSet doExecute(Deployment deployment, ProcessorExecution execution,
-                                  ChangeSet filteredChangeSet, ChangeSet originalChangeSet) {
+    protected ChangeSet doMainProcess(Deployment deployment, ProcessorExecution execution,
+                                      ChangeSet filteredChangeSet, ChangeSet originalChangeSet) {
         logger.info("Test deployment processor running");
 
         return filteredChangeSet;


### PR DESCRIPTION
* Filtering logic moved to AbstractDeployment processor.
* Added ability to skip/jump processors.
* Rebuild context httpMethodCallProcessor now skips directly to fileOutputProcessor when executed successfully.

Ticket craftercms/craftercms#3151
