### PR TITLE
Quick fixes:

### DIFF
--- a/src/main/java/org/craftercms/deployer/impl/processors/DelayProcessor.java
+++ b/src/main/java/org/craftercms/deployer/impl/processors/DelayProcessor.java
@@ -54,7 +54,7 @@ public class DelayProcessor extends AbstractMainDeploymentProcessor {
      */
     @Override
     protected void doInit(final Configuration config) {
-        seconds = config.getLong(CONFIG_KEY_SECONDS, 5);
+        seconds = config.getLong(CONFIG_KEY_SECONDS, 10);
     }
 
     /**

--- a/src/main/resources/aws/cloudformation/serverless-site-stack.yaml
+++ b/src/main/resources/aws/cloudformation/serverless-site-stack.yaml
@@ -3,6 +3,8 @@ Description: Default Crafter Serverless Site Stack
 Parameters:
   S3BucketName:
     Type: String
+  CloudFrontDistributionOriginPath:
+    Type: String
   CloudFrontDistributionAllowedMethods:
     Type: CommaDelimitedList
     Default: 'HEAD,GET'
@@ -81,6 +83,7 @@ Resources:
         Origins:
           - DomainName: !Sub '${S3Bucket}.s3.amazonaws.com'
             Id: !Sub 'S3-${S3Bucket}'
+            OriginPath: !Ref CloudFrontDistributionOriginPath
             S3OriginConfig:
               OriginAccessIdentity: !Sub 'origin-access-identity/cloudfront/${CloudFrontOriginAccessIdentity}'
         Restrictions:

--- a/src/main/resources/templates/targets/aws-cloudformed-s3-target-template.yaml
+++ b/src/main/resources/templates/targets/aws-cloudformed-s3-target-template.yaml
@@ -33,6 +33,7 @@ target:
         templateFilename: serverless-site-stack.yaml
         templateParams:
           S3BucketName: ${aws.cloudformation.s3BucketName}
+          CloudFrontDistributionOriginPath: /${target.siteName}
     init:
       - hookName: waitTillCloudFormationStackUsableLifecycleHook
         region: ${aws.region}


### PR DESCRIPTION
* Default seconds for DelayProcessor is now 10.
* Added CloudFrontDistributionOriginPath to fix permission issue when the site name is the first folder in the S3 bucket.
