### PR TITLE
CloudFront URL fix

### DIFF
--- a/src/main/resources/templates/targets/aws-cloudformed-s3-target-template.yaml
+++ b/src/main/resources/templates/targets/aws-cloudformed-s3-target-template.yaml
@@ -33,7 +33,7 @@ target:
         templateFilename: serverless-site-stack.yaml
         templateParams:
           S3BucketName: ${aws.cloudformation.s3BucketName}
-          CloudFrontDistributionOriginPath: /${target.siteName}
+          CloudFrontDistributionOriginPath: /${target.siteName}/static-assets
     init:
       - hookName: waitTillCloudFormationStackUsableLifecycleHook
         region: ${aws.region}
@@ -87,7 +87,7 @@ target:
       - processorName: gitDiffProcessor
       - processorName: findAndReplaceProcessor
         includeFiles: ['^/site/.*$', '^/templates/.*$', '^/static-assets/.*(js|css|html)$']
-        textPattern: (/static-assets/[^&quot;&lt;]+)
+        textPattern: /static-assets(/[^&quot;&lt;]+)
         replacement: http://${aws.cloudformation.cloudfrontDistribution.domainName}$1
       - processorName: {{#if use_crafter_search}}searchIndexingProcessor{{else}}elasticsearchIndexingProcessor{{/if}}
       - processorName: s3SyncProcessor

--- a/src/main/resources/templates/targets/aws-s3-target-template.yaml
+++ b/src/main/resources/templates/targets/aws-s3-target-template.yaml
@@ -48,7 +48,7 @@ target:
       {{#if aws.distribution.url}}
       - processorName: findAndReplaceProcessor
         includeFiles: ['^/site/.*$', '^/templates/.*$', '^/static-assets/.*(js|css|html)$']
-        textPattern: (/static-assets/[^&quot;&lt;]+)
+        textPattern: /static-assets(/([^&quot;&lt;]+)
         replacement: {{aws.distribution.url}}$1
       {{/if}}
       - processorName: {{#if use_crafter_search}}searchIndexingProcessor{{else}}elasticsearchIndexingProcessor{{/if}}


### PR DESCRIPTION
S3 based targets now by default use CloudFronts with Origin Path to the site's static-assets.

Ticket craftercms/craftercms#3294
