### PR TITLE
The aws.distribution.url is not needed

### DIFF
--- a/src/main/resources/templates/targets/aws-s3-target-template.yaml
+++ b/src/main/resources/templates/targets/aws-s3-target-template.yaml
@@ -48,7 +48,7 @@ target:
         url: {{aws.s3.url}}
       - processorName: delayProcessor
         {{#if delay}}seconds: {{delay}}{{/if}}
-      {{#if aws.distribution.url}}
+      {{#if aws.distribution.ids}}
       - processorName: cloudfrontInvalidationProcessor
         includeFiles: ['^/static-assets/.*$']
         region: ${aws.region}


### PR DESCRIPTION
The `aws.distribution.url` is not needed, replaced with `aws.distribution.ids`
