### PR TITLE
Update Spring Boot version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.1.12.RELEASE</version>
+		<version>2.2.6.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 
@@ -47,7 +47,6 @@
 		<jgit.version>5.4.0.201906121030-r</jgit.version>
 		<javax.mail.version>1.4.7</javax.mail.version>
 		<handlebars.version>4.0.6</handlebars.version>
-		<mockito.version>1.10.19</mockito.version>
 		<sardine.version>5.9</sardine.version>
 		<xerces.version>2.12.0</xerces.version>
 		<java.version>1.8</java.version>
@@ -222,13 +221,6 @@
 			<version>${xerces.version}</version>
 		</dependency>
 
-		<!-- Test -->
-		<dependency>
-			<groupId>org.mockito</groupId>
-			<artifactId>mockito-all</artifactId>
-			<version>${mockito.version}</version>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 
 	<dependencyManagement>


### PR DESCRIPTION
craftercms/craftercms#3782

The mockito dependency was removed because Spring Boot provides a newer version