### PR TITLE
Fixed aws-cloudformed-s3-target-template.yaml

### DIFF
--- a/src/main/resources/templates/targets/aws-cloudformed-s3-target-template.yaml
+++ b/src/main/resources/templates/targets/aws-cloudformed-s3-target-template.yaml
@@ -97,15 +97,12 @@ target:
               {{/if}}
           {{/if}}
       - processorName: gitDiffProcessor
-      - processorName: elasticsearchIndexingProcessor
       - processorName: s3SyncProcessor
         ignoreBlobs: {{#if ignore_blobs}}{{ignore_blobs}}{{else}}true{{/if}}
         region: ${aws.region}
         accessKey: ${aws.accessKey}
         secretKey: ${aws.secretKey}
         url: ${aws.cloudformation.s3Url}
-      - processorName: delayProcessor
-        {{#if delay}}seconds: {{delay}}{{/if}}
       - processorName: cloudfrontInvalidationProcessor
         includeFiles: ['^/static-assets/.*$']
         region: ${aws.region}
@@ -127,6 +124,7 @@ target:
         accessKey: ${aws.accessKey}
         secretKey: ${aws.secretKey}
         url: ${aws.cloudformation.s3Url}
+      - processorName: elasticsearchIndexingProcessor
       # -------------------- END OF MAIN PIPELINE --------------------
       - processorName: fileOutputProcessor
       {{#if notification_addresses}}


### PR DESCRIPTION
Fixed aws-cloudformed-s3-target-template.yaml by moving ES processor to the end and removing delay processor
