### PR TITLE
ClearS3BucketLifecycleHook fixes

### DIFF
--- a/src/main/java/org/craftercms/deployer/impl/lifecycle/aws/ClearS3BucketLifecycleHook.java
+++ b/src/main/java/org/craftercms/deployer/impl/lifecycle/aws/ClearS3BucketLifecycleHook.java
@@ -79,18 +79,18 @@ public class ClearS3BucketLifecycleHook extends AbstractLifecycleHook {
                         logger.info("Deleting {} objects", objectsToDelete.size());
 
                         s3.deleteObjects(new DeleteObjectsRequest(bucketName).withKeys(objectsToDelete));
-
-                        // If the bucket contains many objects, the listObjects() call
-                        // might not return all of the objects in the first listing. Check to
-                        // see whether the listing was truncated. If so, retrieve the next page of objects
-                        // and delete them.
-                        if (objectList.isTruncated()) {
-                            objectList = s3.listNextBatchOfObjects(objectList);
-                        } else {
-                            break;
-                        }
                     } else {
                         logger.info("No objects to delete");
+                    }
+
+                    // If the bucket contains many objects, the listObjects() call
+                    // might not return all of the objects in the first listing. Check to
+                    // see whether the listing was truncated. If so, retrieve the next page of objects
+                    // and delete them.
+                    if (objectList.isTruncated()) {
+                        objectList = s3.listNextBatchOfObjects(objectList);
+                    } else {
+                        break;
                     }
                 }
 
@@ -105,14 +105,14 @@ public class ClearS3BucketLifecycleHook extends AbstractLifecycleHook {
                         logger.info("Deleting {} object versions", versionsToDelete.size());
 
                         s3.deleteObjects(new DeleteObjectsRequest(bucketName).withKeys(versionsToDelete));
-
-                        if (versionList.isTruncated()) {
-                            versionList = s3.listNextBatchOfVersions(versionList);
-                        } else {
-                            break;
-                        }
                     } else {
                         logger.info("No object versions to delete");
+                    }
+
+                    if (versionList.isTruncated()) {
+                        versionList = s3.listNextBatchOfVersions(versionList);
+                    } else {
+                        break;
                     }
                 }
             }

--- a/src/main/resources/base-target-context.xml
+++ b/src/main/resources/base-target-context.xml
@@ -28,14 +28,20 @@
 
     <!-- Lifecycle hooks -->
 
-    <bean id="createIndexLifecycleHook" class="org.craftercms.deployer.impl.lifecycle.CreateIndexLifecycleHook">
+    <!--
+        All hooks should be prototypes, so that several instances of them can be used. They will be instanced when the
+        pipeline is created
+    -->
+    <bean id="createIndexLifecycleHook" class="org.craftercms.deployer.impl.lifecycle.CreateIndexLifecycleHook"
+          scope="prototype">
         <property name="siteName" value="${target.siteName}"/>
         <property name="indexIdFormat" value="${target.search.indexIdFormat}"/>
         <property name="crafterSearchAdminService" ref="searchAdminService"/>
         <property name="elasticsearchAdminService" ref="elasticsearchAdminService"/>
     </bean>
 
-    <bean id="deleteIndexLifecycleHook" class="org.craftercms.deployer.impl.lifecycle.DeleteIndexLifecycleHook">
+    <bean id="deleteIndexLifecycleHook" class="org.craftercms.deployer.impl.lifecycle.DeleteIndexLifecycleHook"
+          scope="prototype">
         <property name="siteName" value="${target.siteName}"/>
         <property name="indexIdFormat" value="${target.search.indexIdFormat}"/>
         <property name="crafterSearchAdminService" ref="searchAdminService"/>
@@ -43,24 +49,25 @@
     </bean>
 
     <bean id="createCloudFormationLifecycleHook"
-          class="org.craftercms.deployer.impl.lifecycle.aws.CreateCloudFormationLifecycleHook">
+          class="org.craftercms.deployer.impl.lifecycle.aws.CreateCloudFormationLifecycleHook" scope="prototype">
         <property name="templatesResource" value="${deployer.main.targets.config.aws.cloudformation.location}"/>
         <property name="templatesOverrideResource" value="${deployer.main.targets.config.aws.cloudformation.overrideLocation}"/>
     </bean>
 
     <bean id="deleteCloudFormationLifecycleHook"
-          class="org.craftercms.deployer.impl.lifecycle.aws.DeleteCloudFormationLifecycleHook"/>
+          class="org.craftercms.deployer.impl.lifecycle.aws.DeleteCloudFormationLifecycleHook" scope="prototype"/>
 
     <bean id="waitTillCloudFormationStackUsableLifecycleHook"
-          class="org.craftercms.deployer.impl.lifecycle.aws.WaitTillCloudFormationStackUsableLifecycleHook">
+          class="org.craftercms.deployer.impl.lifecycle.aws.WaitTillCloudFormationStackUsableLifecycleHook"
+          scope="prototype">
         <property name="targetConfig" ref="targetConfig"/>
     </bean>
 
     <bean id="clearS3BucketLifecycleHook"
-          class="org.craftercms.deployer.impl.lifecycle.aws.ClearS3BucketLifecycleHook"/>
+          class="org.craftercms.deployer.impl.lifecycle.aws.ClearS3BucketLifecycleHook" scope="prototype"/>
 
     <bean id="deleteLocalRepoFolderLifecycleHook"
-          class="org.craftercms.deployer.impl.lifecycle.DeleteLocalRepoFolderLifecycleHook">
+          class="org.craftercms.deployer.impl.lifecycle.DeleteLocalRepoFolderLifecycleHook" scope="prototype">
         <property name="localRepoFolder" value="${target.localRepoPath}"/>
     </bean>
 


### PR DESCRIPTION
- Deletes all objects and versions
- Avoids sending delete requests when the bucket is empty
- Made all lifecycle hooks prototype
