### PR TITLE
Removing unused target parameter from doCreateIndexIfMissing. Moving …

### DIFF
--- a/src/main/java/org/craftercms/deployer/impl/processors/AbstractSearchIndexingProcessor.java
+++ b/src/main/java/org/craftercms/deployer/impl/processors/AbstractSearchIndexingProcessor.java
@@ -21,7 +21,6 @@ import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.lang3.StringUtils;
 import org.craftercms.commons.config.ConfigurationException;
 import org.craftercms.core.util.cache.CacheTemplate;
-import org.craftercms.deployer.api.Target;
 import org.craftercms.search.batch.BatchIndexer;
 import org.craftercms.search.batch.UpdateSet;
 import org.craftercms.search.batch.UpdateStatus;

--- a/src/main/java/org/craftercms/deployer/impl/processors/AbstractSearchIndexingProcessor.java
+++ b/src/main/java/org/craftercms/deployer/impl/processors/AbstractSearchIndexingProcessor.java
@@ -199,18 +199,7 @@ public abstract class AbstractSearchIndexingProcessor extends AbstractMainDeploy
         return mode == Deployment.Mode.PUBLISH || mode == Deployment.Mode.SEARCH_INDEX;
     }
 
-    @Override
-    public void execute(Deployment deployment) {
-        if (createIndexIfMissing) {
-            logger.info("Checking if index {} exists", indexId);
-            doCreateIndexIfMissing(deployment.getTarget());
-        }
-
-        // continue as usual
-        super.execute(deployment);
-    }
-
-    protected abstract void doCreateIndexIfMissing(Target target);
+    protected abstract void doCreateIndexIfMissing();
 
     /**
      * Override to add pages/components that need to be updated because a component that they include was updated.
@@ -220,6 +209,10 @@ public abstract class AbstractSearchIndexingProcessor extends AbstractMainDeploy
      */
     @Override
     protected ChangeSet getFilteredChangeSet(ChangeSet changeSet) {
+        if (createIndexIfMissing) {
+            logger.info("Ensuring that index {} exists", indexId);
+            doCreateIndexIfMissing();
+        }
         changeSet = super.getFilteredChangeSet(changeSet);
         if (changeSet != null && !changeSet.isEmpty() && xmlFlatteningEnabled) {
             List<String> createdFiles = changeSet.getCreatedFiles();

--- a/src/main/java/org/craftercms/deployer/impl/processors/elasticsearch/ElasticsearchIndexingProcessor.java
+++ b/src/main/java/org/craftercms/deployer/impl/processors/elasticsearch/ElasticsearchIndexingProcessor.java
@@ -63,7 +63,7 @@ public class ElasticsearchIndexingProcessor extends AbstractSearchIndexingProces
     }
 
     @Override
-    protected void doCreateIndexIfMissing(Target target) {
+    protected void doCreateIndexIfMissing() {
         elasticsearchAdminService.createIndex(indexId);
     }
 


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/5587

Removing unused target parameter from doCreateIndexIfMissing. Moving missing index creation so exceptions are caught and logged properly.
