### PR TITLE
Ignore 'index.version.upgraded' index setting when re-creating

### DIFF
--- a/src/main/resources/base-target.yaml
+++ b/src/main/resources/base-target.yaml
@@ -65,6 +65,7 @@ target:
         - "index.provided_name"
         - "index.number_of_shards"
         - "index.replication.type"
+        - "index.version.upgraded"
     indexing:
       xml:
         flattening:


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/6610
Fix recreate index by aliasname