### PR TITLE
Prevent searching for components or inheritors when reprocessing ALL

### DIFF
--- a/src/main/java/org/craftercms/deployer/impl/processors/AbstractDeploymentProcessor.java
+++ b/src/main/java/org/craftercms/deployer/impl/processors/AbstractDeploymentProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2022 Crafter Software Corporation. All Rights Reserved.
+ * Copyright (C) 2007-2024 Crafter Software Corporation. All Rights Reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as published by
@@ -23,8 +23,10 @@ import org.craftercms.commons.lang.RegexUtils;
 import org.craftercms.deployer.api.ChangeSet;
 import org.craftercms.deployer.api.Deployment;
 import org.craftercms.deployer.api.DeploymentProcessor;
+import org.craftercms.deployer.api.Target;
 import org.craftercms.deployer.api.exceptions.DeployerException;
 import org.craftercms.deployer.impl.DeploymentConstants;
+import org.craftercms.deployer.impl.TargetImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.BeanNameAware;
@@ -213,6 +215,20 @@ public abstract class AbstractDeploymentProcessor implements DeploymentProcessor
         logger.info("Jumping to processor of target '" + targetId + "' with label '" + jumpTo + "'");
 
         deployment.addParam(JUMPING_TO_PARAM_NAME, jumpTo);
+    }
+
+    /**
+     * Get a param from the current deployment
+     * @param param the param name
+     * @return the param value, or null if the param is not set or current deployment is null
+     */
+    protected Object getDeploymentParam(String param) {
+        Target target = TargetImpl.getCurrent();
+        if (target == null) {
+            return null;
+        }
+        Deployment currentDeployment = target.getCurrentDeployment();
+        return currentDeployment == null ? null : currentDeployment.getParam(param);
     }
 
     /**

--- a/src/main/java/org/craftercms/deployer/impl/processors/AbstractSearchIndexingProcessor.java
+++ b/src/main/java/org/craftercms/deployer/impl/processors/AbstractSearchIndexingProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2022 Crafter Software Corporation. All Rights Reserved.
+ * Copyright (C) 2007-2024 Crafter Software Corporation. All Rights Reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as published by
@@ -27,6 +27,7 @@ import org.craftercms.deployer.api.ChangeSet;
 import org.craftercms.deployer.api.Deployment;
 import org.craftercms.deployer.api.ProcessorExecution;
 import org.craftercms.deployer.api.exceptions.DeployerException;
+import org.craftercms.deployer.utils.BooleanUtils;
 import org.craftercms.search.batch.BatchIndexer;
 import org.craftercms.search.batch.UpdateSet;
 import org.craftercms.search.batch.UpdateStatus;
@@ -43,6 +44,7 @@ import java.util.regex.Pattern;
 import static org.apache.commons.collections4.ListUtils.emptyIfNull;
 import static org.craftercms.commons.config.ConfigUtils.getBooleanProperty;
 import static org.craftercms.commons.config.ConfigUtils.getStringProperty;
+import static org.craftercms.deployer.impl.DeploymentConstants.REPROCESS_ALL_FILES_PARAM_NAME;
 
 /**
  * Processor that indexes the files on the change set, using one or several {@link BatchIndexer}. After the files have
@@ -208,8 +210,9 @@ public abstract class AbstractSearchIndexingProcessor extends AbstractMainDeploy
             logger.info("Ensuring that index {} exists", indexId);
             doCreateIndexIfMissing();
         }
+        boolean isReprocessAll = BooleanUtils.toBoolean(getDeploymentParam(REPROCESS_ALL_FILES_PARAM_NAME));
         changeSet = super.getFilteredChangeSet(changeSet);
-        if (changeSet != null && !changeSet.isEmpty() && xmlFlatteningEnabled) {
+        if (changeSet != null && !changeSet.isEmpty() && xmlFlatteningEnabled && !isReprocessAll) {
             List<String> createdFiles = changeSet.getCreatedFiles();
             List<String> updatedFiles = changeSet.getUpdatedFiles();
             List<String> deletedFiles = changeSet.getDeletedFiles();


### PR DESCRIPTION
https://github.com/craftersoftware/craftercms/issues/842
Prevent searching for components or inheritors when reprocessing ALL