### PR TITLE
Remove duplicate mapping key in OAS #6891

### DIFF
--- a/src/main/api/deployer-api.yaml
+++ b/src/main/api/deployer-api.yaml
@@ -696,14 +696,3 @@ components:
               message:
                 type: string
                 example: OK
-
-    Created:
-      description: Created
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              message:
-                type: string
-                example: OK


### PR DESCRIPTION
### Ticket reference or full description of what's in the PR
Remove duplicate mapping key `Created` under responses in OAS https://github.com/craftercms/craftercms/issues/6891