### PR TITLE
Recreate index to use indexIdFormat property

### DIFF
--- a/src/main/java/org/craftercms/deployer/api/Target.java
+++ b/src/main/java/org/craftercms/deployer/api/Target.java
@@ -34,6 +34,7 @@ import java.util.Map;
  * @author avasquez
  */
 public interface Target {
+    String INDEX_ID_FORMAT_CONFIG_KEY = "target.search.indexIdFormat";
 
 	String AUTHORING_ENV = "authoring";
 

--- a/src/main/java/org/craftercms/deployer/api/TargetService.java
+++ b/src/main/java/org/craftercms/deployer/api/TargetService.java
@@ -15,6 +15,7 @@
  */
 package org.craftercms.deployer.api;
 
+import org.craftercms.commons.config.ConfigurationException;
 import org.craftercms.deployer.api.exceptions.TargetAlreadyExistsException;
 import org.craftercms.deployer.api.exceptions.TargetNotFoundException;
 import org.craftercms.deployer.api.exceptions.TargetServiceException;
@@ -101,7 +102,7 @@ public interface TargetService {
 	 * @param siteName the target's site name (e.g. mysite)
 	 * @throws TargetNotFoundException if the target for the specified env and site name doesn't exist
 	 */
-	void recreateIndex(String env, String siteName) throws TargetNotFoundException;
+	void recreateIndex(String env, String siteName) throws TargetNotFoundException, ConfigurationException;
 
 	/**
 	 * Duplicates a target.

--- a/src/main/java/org/craftercms/deployer/impl/TargetServiceImpl.java
+++ b/src/main/java/org/craftercms/deployer/impl/TargetServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2024 Crafter Software Corporation. All Rights Reserved.
+ * Copyright (C) 2007-2025 Crafter Software Corporation. All Rights Reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as published by
@@ -70,6 +70,7 @@ import static java.lang.String.format;
 import static org.apache.commons.collections.CollectionUtils.isEmpty;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 import static org.craftercms.commons.config.ConfigUtils.getRequiredStringProperty;
+import static org.craftercms.deployer.api.Target.INDEX_ID_FORMAT_CONFIG_KEY;
 import static org.craftercms.deployer.impl.DeploymentConstants.*;
 
 /**
@@ -282,11 +283,14 @@ public class TargetServiceImpl implements TargetService, ApplicationListener<App
 	}
 
 	@Override
-	public void recreateIndex(String env, String siteName) throws TargetNotFoundException {
+	public void recreateIndex (String env, String siteName) throws TargetNotFoundException, ConfigurationException {
 		Target target = getTarget(env, siteName);
 		ApplicationContext appContext = target.getApplicationContext();
 		OpenSearchAdminService adminService = appContext.getBean(OpenSearchAdminService.class);
-		adminService.recreateIndex(target.getId());
+
+		String indexIdFormat = getRequiredStringProperty(target.getConfiguration(), INDEX_ID_FORMAT_CONFIG_KEY);
+		String indexName = String.format(indexIdFormat, siteName);
+		adminService.recreateIndex(indexName);
 	}
 
 	@Override

--- a/src/main/java/org/craftercms/deployer/impl/rest/TargetController.java
+++ b/src/main/java/org/craftercms/deployer/impl/rest/TargetController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2024 Crafter Software Corporation. All Rights Reserved.
+ * Copyright (C) 2007-2025 Crafter Software Corporation. All Rights Reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as published by
@@ -16,6 +16,7 @@
 package org.craftercms.deployer.impl.rest;
 
 import org.apache.commons.lang3.StringUtils;
+import org.craftercms.commons.config.ConfigurationException;
 import org.craftercms.commons.exceptions.InvalidManagementTokenException;
 import org.craftercms.commons.rest.RestServiceUtils;
 import org.craftercms.commons.rest.Result;
@@ -331,10 +332,10 @@ public class TargetController {
 	 */
 	@RequestMapping(value = RECREATE_INDEX_URL, method = RequestMethod.POST)
 	public ResponseEntity<Result> recreateIndex(@NotBlank @ValidateNoTagsParam
-						    @ValidateSecurePathParam @PathVariable(ENV_PATH_VAR_NAME) String env,
-						    @NotBlank @EsapiValidatedParam(type = SITE_ID) @PathVariable(SITE_NAME_PATH_VAR_NAME) String siteName,
-						    @RequestParam String token)
-		throws DeployerException, InvalidManagementTokenException {
+												@ValidateSecurePathParam @PathVariable(ENV_PATH_VAR_NAME) String env,
+												@NotBlank @EsapiValidatedParam(type = SITE_ID) @PathVariable(SITE_NAME_PATH_VAR_NAME) String siteName,
+												@RequestParam String token)
+			throws DeployerException, InvalidManagementTokenException, ConfigurationException {
 		validateToken(token);
 		targetService.recreateIndex(env, siteName);
 

--- a/src/main/java/org/craftercms/deployer/impl/upgrade/operations/ElasticsearchIndexUpgradeOperation.java
+++ b/src/main/java/org/craftercms/deployer/impl/upgrade/operations/ElasticsearchIndexUpgradeOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2022 Crafter Software Corporation. All Rights Reserved.
+ * Copyright (C) 2007-2025 Crafter Software Corporation. All Rights Reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as published by
@@ -23,6 +23,7 @@ import org.craftercms.deployer.api.Target;
 import org.craftercms.search.opensearch.OpenSearchAdminService;
 
 import static org.craftercms.commons.config.ConfigUtils.getRequiredStringProperty;
+import static org.craftercms.deployer.api.Target.INDEX_ID_FORMAT_CONFIG_KEY;
 import static org.craftercms.deployer.impl.DeploymentConstants.PROCESSOR_NAME_CONFIG_KEY;
 import static org.craftercms.deployer.impl.DeploymentConstants.TARGET_DEPLOYMENT_PIPELINE_CONFIG_KEY;
 
@@ -34,7 +35,6 @@ import static org.craftercms.deployer.impl.DeploymentConstants.TARGET_DEPLOYMENT
  */
 public class ElasticsearchIndexUpgradeOperation extends AbstractUpgradeOperation<Target> {
 
-	protected static final String INDEX_ID_FORMAT_CONFIG_KEY = "target.search.indexIdFormat";
 	protected static final String PROCESSOR_NAME_PATTERN = "(authoringE|e)lasticsearchIndexingProcessor";
 
 	protected boolean containsProcessor(HierarchicalConfiguration<?> config) {


### PR DESCRIPTION
Recreate index to use indexIdFormat property
https://github.com/craftercms/craftercms/issues/8254

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced index recreation to support configurable index name formats based on site name.

* **Bug Fixes**
  * Improved error handling during index recreation by introducing additional configuration-related exception reporting.

* **Chores**
  * Updated copyright years.
  * Refactored usage of configuration keys for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->