### PR TITLE
Retry targets when init has failed. Limit the number of attempts for target init

### DIFF
--- a/src/main/java/org/craftercms/deployer/api/Target.java
+++ b/src/main/java/org/craftercms/deployer/api/Target.java
@@ -157,6 +157,16 @@ public interface Target {
 	 */
 	void unlock();
 
+    /**
+     * Returns the number of retry attempts left for the current deployment.
+     * This is used to retry deployments a maximum number of attempts
+     * if they fail to init after creation
+     *
+     * @return the number of retry attempts left
+     */
+    int getInitRetryAttempts();
+
+
 	/**
 	 * Call the appropriate event listeners for the given event type.
 	 *

--- a/src/main/java/org/craftercms/deployer/api/Target.java
+++ b/src/main/java/org/craftercms/deployer/api/Target.java
@@ -157,14 +157,14 @@ public interface Target {
 	 */
 	void unlock();
 
-    /**
-     * Returns the number of retry attempts left for the current deployment.
-     * This is used to retry deployments a maximum number of attempts
-     * if they fail to init after creation
-     *
-     * @return the number of retry attempts left
-     */
-    int getInitRetryAttempts();
+	/**
+	 * Returns the number of retry attempts left for the current deployment.
+	 * This is used to retry deployments a maximum number of attempts
+	 * if they fail to init after creation
+	 *
+	 * @return the number of retry attempts left
+	 */
+	int getInitRetryAttempts();
 
 
 	/**

--- a/src/main/java/org/craftercms/deployer/impl/TargetImpl.java
+++ b/src/main/java/org/craftercms/deployer/impl/TargetImpl.java
@@ -85,6 +85,7 @@ public class TargetImpl implements Target {
 	protected volatile Deployment currentDeployment;
 	protected final Lock deploymentLock;
 	protected Map<String, List<TargetEventListener>> eventListeners;
+	private int initRetryAttempts;
 
 	public static void setCurrent(Target target) {
 		threadLocal.set(target);
@@ -201,6 +202,7 @@ public class TargetImpl implements Target {
 			status = Status.INIT_COMPLETED;
 		} catch (Exception e) {
 			status = Status.INIT_FAILED;
+			initRetryAttempts--;
 
 			logger.error("Failed to init target '{}'", getId(), e);
 		}
@@ -273,6 +275,11 @@ public class TargetImpl implements Target {
 		}
 
 		return deployments;
+	}
+
+	@Override
+	public int getInitRetryAttempts() {
+		return initRetryAttempts;
 	}
 
 	/**
@@ -531,6 +538,10 @@ public class TargetImpl implements Target {
 				", siteName='" + siteName + '\'' +
 				", configurationFile=" +
 				configurationFile + '}';
+	}
+
+	public void setInitRetryAttempts(int initRetryAttempts) {
+		this.initRetryAttempts = initRetryAttempts;
 	}
 
 }

--- a/src/main/java/org/craftercms/deployer/impl/TargetServiceImpl.java
+++ b/src/main/java/org/craftercms/deployer/impl/TargetServiceImpl.java
@@ -82,210 +82,210 @@ import static org.craftercms.deployer.impl.DeploymentConstants.*;
 @Component("targetService")
 @DependsOn("crafter.cacheStoreAdapter")
 public class TargetServiceImpl implements TargetService, ApplicationListener<ApplicationReadyEvent>,
-        InitializingBean, DisposableBean {
+		InitializingBean, DisposableBean {
 
-    private static final Logger logger = LoggerFactory.getLogger(TargetServiceImpl.class);
+	private static final Logger logger = LoggerFactory.getLogger(TargetServiceImpl.class);
 
-    public static final String YAML_FILE_EXTENSION = "yaml";
-    public static final String APPLICATION_CONTEXT_FILENAME_FORMAT = "%s-context.xml";
-    public static final String CONFIG_PROPERTY_SOURCE_NAME = "targetConfig";
-    public static final String CONFIG_BEAN_NAME = "targetConfig";
+	public static final String YAML_FILE_EXTENSION = "yaml";
+	public static final String APPLICATION_CONTEXT_FILENAME_FORMAT = "%s-context.xml";
+	public static final String CONFIG_PROPERTY_SOURCE_NAME = "targetConfig";
+	public static final String CONFIG_BEAN_NAME = "targetConfig";
 
-    public static final String TARGET_ENV_MODEL_KEY = "env";
-    public static final String TARGET_SITE_NAME_MODEL_KEY = "site_name";
-    public static final String TARGET_SOURCE_TARGET_MODEL_KEY = "source_target";
-    public static final String TARGET_ID_MODEL_KEY = "target_id";
+	public static final String TARGET_ENV_MODEL_KEY = "env";
+	public static final String TARGET_SITE_NAME_MODEL_KEY = "site_name";
+	public static final String TARGET_SOURCE_TARGET_MODEL_KEY = "source_target";
+	public static final String TARGET_ID_MODEL_KEY = "target_id";
 
-    protected final File targetConfigFolder;
-    protected final Resource baseTargetYamlConfigResource;
-    protected final Resource baseTargetYamlConfigOverrideResource;
-    protected final Resource baseTargetContextResource;
-    protected final Resource baseTargetContextOverrideResource;
-    protected final String defaultTargetConfigTemplateName;
-    protected final Handlebars targetConfigTemplateEngine;
-    protected final ApplicationContext mainApplicationContext;
-    protected final DeploymentPipelineFactory deploymentPipelineFactory;
-    protected final TaskScheduler taskScheduler;
-    protected final ExecutorService taskExecutor;
-    protected final ProcessedCommitsStore processedCommitsStore;
-    protected final ProcessorStateStore processorStateStore;
-    protected final TargetLifecycleHooksResolver targetLifecycleHooksResolver;
-    protected final EncryptionAwareConfigurationReader configurationReader;
-    protected final UpgradeManager<Target> upgradeManager;
-    protected final Set<Target> currentTargets;
-    protected final int maxTargetInitRetryAttempts;
+	protected final File targetConfigFolder;
+	protected final Resource baseTargetYamlConfigResource;
+	protected final Resource baseTargetYamlConfigOverrideResource;
+	protected final Resource baseTargetContextResource;
+	protected final Resource baseTargetContextOverrideResource;
+	protected final String defaultTargetConfigTemplateName;
+	protected final Handlebars targetConfigTemplateEngine;
+	protected final ApplicationContext mainApplicationContext;
+	protected final DeploymentPipelineFactory deploymentPipelineFactory;
+	protected final TaskScheduler taskScheduler;
+	protected final ExecutorService taskExecutor;
+	protected final ProcessedCommitsStore processedCommitsStore;
+	protected final ProcessorStateStore processorStateStore;
+	protected final TargetLifecycleHooksResolver targetLifecycleHooksResolver;
+	protected final EncryptionAwareConfigurationReader configurationReader;
+	protected final UpgradeManager<Target> upgradeManager;
+	protected final Set<Target> currentTargets;
+	protected final int maxTargetInitRetryAttempts;
 
-    public TargetServiceImpl(
-            @Value("${deployer.main.targets.config.folderPath}") File targetConfigFolder,
-            @Value("${deployer.main.targets.config.baseYaml.location}") Resource baseTargetYamlConfigResource,
-            @Value("${deployer.main.targets.config.baseYaml.overrideLocation}") Resource baseTargetYamlConfigOverrideResource,
-            @Value("${deployer.main.targets.config.baseContext.location}") Resource baseTargetContextResource,
-            @Value("${deployer.main.targets.config.baseContext.overrideLocation}") Resource baseTargetContextOverrideResource,
-            @Value("${deployer.main.targets.config.templates.default}") String defaultTargetConfigTemplateName,
-            @Value("${deployer.main.targets.maxInitRetries}") int maxTargetInitRetryAttempts,
-            @Autowired Handlebars targetConfigTemplateEngine,
-            @Autowired ApplicationContext mainApplicationContext,
-            @Autowired DeploymentPipelineFactory deploymentPipelineFactory,
-            @Autowired TaskScheduler taskScheduler,
-            @Autowired ExecutorService taskExecutor,
-            @Autowired ProcessedCommitsStore processedCommitsStore,
-            @Autowired ProcessorStateStore processorStateStore,
-            @Autowired TargetLifecycleHooksResolver targetLifecycleHooksResolver,
-            @Autowired EncryptionAwareConfigurationReader configurationReader,
-            @Autowired UpgradeManager<Target> upgradeManager) {
-        this.targetConfigFolder = targetConfigFolder;
-        this.baseTargetYamlConfigResource = baseTargetYamlConfigResource;
-        this.baseTargetYamlConfigOverrideResource = baseTargetYamlConfigOverrideResource;
-        this.baseTargetContextResource = baseTargetContextResource;
-        this.baseTargetContextOverrideResource = baseTargetContextOverrideResource;
-        this.defaultTargetConfigTemplateName = defaultTargetConfigTemplateName;
-        this.targetConfigTemplateEngine = targetConfigTemplateEngine;
-        this.mainApplicationContext = mainApplicationContext;
-        this.deploymentPipelineFactory = deploymentPipelineFactory;
-        this.taskScheduler = taskScheduler;
-        this.taskExecutor = taskExecutor;
-        this.processedCommitsStore = processedCommitsStore;
-        this.processorStateStore = processorStateStore;
-        this.targetLifecycleHooksResolver = targetLifecycleHooksResolver;
-        this.configurationReader = configurationReader;
-        this.upgradeManager = upgradeManager;
-        this.currentTargets = new CopyOnWriteArraySet<>();
-        this.maxTargetInitRetryAttempts = maxTargetInitRetryAttempts;
-    }
+	public TargetServiceImpl(
+			@Value("${deployer.main.targets.config.folderPath}") File targetConfigFolder,
+			@Value("${deployer.main.targets.config.baseYaml.location}") Resource baseTargetYamlConfigResource,
+			@Value("${deployer.main.targets.config.baseYaml.overrideLocation}") Resource baseTargetYamlConfigOverrideResource,
+			@Value("${deployer.main.targets.config.baseContext.location}") Resource baseTargetContextResource,
+			@Value("${deployer.main.targets.config.baseContext.overrideLocation}") Resource baseTargetContextOverrideResource,
+			@Value("${deployer.main.targets.config.templates.default}") String defaultTargetConfigTemplateName,
+			@Value("${deployer.main.targets.maxInitRetries}") int maxTargetInitRetryAttempts,
+			@Autowired Handlebars targetConfigTemplateEngine,
+			@Autowired ApplicationContext mainApplicationContext,
+			@Autowired DeploymentPipelineFactory deploymentPipelineFactory,
+			@Autowired TaskScheduler taskScheduler,
+			@Autowired ExecutorService taskExecutor,
+			@Autowired ProcessedCommitsStore processedCommitsStore,
+			@Autowired ProcessorStateStore processorStateStore,
+			@Autowired TargetLifecycleHooksResolver targetLifecycleHooksResolver,
+			@Autowired EncryptionAwareConfigurationReader configurationReader,
+			@Autowired UpgradeManager<Target> upgradeManager) {
+		this.targetConfigFolder = targetConfigFolder;
+		this.baseTargetYamlConfigResource = baseTargetYamlConfigResource;
+		this.baseTargetYamlConfigOverrideResource = baseTargetYamlConfigOverrideResource;
+		this.baseTargetContextResource = baseTargetContextResource;
+		this.baseTargetContextOverrideResource = baseTargetContextOverrideResource;
+		this.defaultTargetConfigTemplateName = defaultTargetConfigTemplateName;
+		this.targetConfigTemplateEngine = targetConfigTemplateEngine;
+		this.mainApplicationContext = mainApplicationContext;
+		this.deploymentPipelineFactory = deploymentPipelineFactory;
+		this.taskScheduler = taskScheduler;
+		this.taskExecutor = taskExecutor;
+		this.processedCommitsStore = processedCommitsStore;
+		this.processorStateStore = processorStateStore;
+		this.targetLifecycleHooksResolver = targetLifecycleHooksResolver;
+		this.configurationReader = configurationReader;
+		this.upgradeManager = upgradeManager;
+		this.currentTargets = new CopyOnWriteArraySet<>();
+		this.maxTargetInitRetryAttempts = maxTargetInitRetryAttempts;
+	}
 
-    public void afterPropertiesSet() throws DeployerException {
-        if (targetConfigFolder.exists()) {
-            return;
-        }
-        logger.info("Target config folder '{}' doesn't exist. Creating it", targetConfigFolder);
+	public void afterPropertiesSet() throws DeployerException {
+		if (targetConfigFolder.exists()) {
+			return;
+		}
+		logger.info("Target config folder '{}' doesn't exist. Creating it", targetConfigFolder);
 
-        try {
-            FileUtils.forceMkdir(targetConfigFolder);
-        } catch (IOException e) {
-            throw new DeployerException(format("Failed to create target config folder at '%s'", targetConfigFolder));
-        }
-    }
+		try {
+			FileUtils.forceMkdir(targetConfigFolder);
+		} catch (IOException e) {
+			throw new DeployerException(format("Failed to create target config folder at '%s'", targetConfigFolder));
+		}
+	}
 
-    @Override
-    public void onApplicationEvent(@NonNull ApplicationReadyEvent event) {
-        // Load all existing targets on startup
-        try {
-            List<Target> targets = resolveTargets();
-            if (CollectionUtils.isEmpty(targets)) {
-                logger.warn("No config files found under '{}'", targetConfigFolder.getAbsolutePath());
-            } else {
-                // check if there are any targets that need to be unlocked
-                targets.forEach(Target::unlock);
-            }
-        } catch (DeployerException e) {
-            logger.error("Error while loading targets on startup", e);
-        }
-    }
+	@Override
+	public void onApplicationEvent(@NonNull ApplicationReadyEvent event) {
+		// Load all existing targets on startup
+		try {
+			List<Target> targets = resolveTargets();
+			if (CollectionUtils.isEmpty(targets)) {
+				logger.warn("No config files found under '{}'", targetConfigFolder.getAbsolutePath());
+			} else {
+				// check if there are any targets that need to be unlocked
+				targets.forEach(Target::unlock);
+			}
+		} catch (DeployerException e) {
+			logger.error("Error while loading targets on startup", e);
+		}
+	}
 
-    @Override
-    public void destroy() {
-        logger.info("Closing all targets...");
+	@Override
+	public void destroy() {
+		logger.info("Closing all targets...");
 
-        if (isNotEmpty(currentTargets)) {
-            currentTargets.forEach(Target::close);
-        }
-    }
+		if (isNotEmpty(currentTargets)) {
+			currentTargets.forEach(Target::close);
+		}
+	}
 
-    @Override
-    public List<Target> getAllTargets() {
-        return new ArrayList<>(currentTargets);
-    }
+	@Override
+	public List<Target> getAllTargets() {
+		return new ArrayList<>(currentTargets);
+	}
 
-    @Override
-    public boolean targetExists(String env, String siteName) {
-        String id = TargetImpl.getId(env, siteName);
+	@Override
+	public boolean targetExists(String env, String siteName) {
+		String id = TargetImpl.getId(env, siteName);
 
-        return findLoadedTargetById(id) != null;
-    }
+		return findLoadedTargetById(id) != null;
+	}
 
-    @Override
-    public Target getTarget(String env, String siteName) throws TargetNotFoundException {
-        String id = TargetImpl.getId(env, siteName);
-        Target target = findLoadedTargetById(id);
+	@Override
+	public Target getTarget(String env, String siteName) throws TargetNotFoundException {
+		String id = TargetImpl.getId(env, siteName);
+		Target target = findLoadedTargetById(id);
 
-        if (target != null) {
-            return target;
-        }
-        throw new TargetNotFoundException(id, env, siteName);
-    }
+		if (target != null) {
+			return target;
+		}
+		throw new TargetNotFoundException(id, env, siteName);
+	}
 
-    @Override
-    public synchronized List<Target> resolveTargets() throws TargetServiceException {
-        Collection<File> configFiles = getTargetConfigFiles();
-        List<Target> targets = new ArrayList<>();
+	@Override
+	public synchronized List<Target> resolveTargets() throws TargetServiceException {
+		Collection<File> configFiles = getTargetConfigFiles();
+		List<Target> targets = new ArrayList<>();
 
-        if (!isNotEmpty(configFiles)) {
-            return targets;
-        }
-        closeTargetsWithNoConfigFile(configFiles);
+		if (!isNotEmpty(configFiles)) {
+			return targets;
+		}
+		closeTargetsWithNoConfigFile(configFiles);
 
-        for (File file : configFiles) {
-            Target target = resolveTargetFromConfigFile(file, LoadMode.LOAD);
-            targets.add(target);
-        }
+		for (File file : configFiles) {
+			Target target = resolveTargetFromConfigFile(file, LoadMode.LOAD);
+			targets.add(target);
+		}
 
-        return targets;
-    }
+		return targets;
+	}
 
-    @Override
-    public synchronized Target createTarget(String env, String siteName, boolean replace, String templateName,
-                                            Map<String, Object> templateParams)
-            throws TargetAlreadyExistsException,
-            TargetServiceException {
-        String id = TargetImpl.getId(env, siteName);
-        File configFile = new File(targetConfigFolder, id + "." + YAML_FILE_EXTENSION);
+	@Override
+	public synchronized Target createTarget(String env, String siteName, boolean replace, String templateName,
+											Map<String, Object> templateParams)
+			throws TargetAlreadyExistsException,
+			TargetServiceException {
+		String id = TargetImpl.getId(env, siteName);
+		File configFile = new File(targetConfigFolder, id + "." + YAML_FILE_EXTENSION);
 
-        if (!replace && configFile.exists()) {
-            throw new TargetAlreadyExistsException(id, env, siteName);
-        }
-        createConfigFromTemplate(env, siteName, id, templateName, templateParams, configFile);
+		if (!replace && configFile.exists()) {
+			throw new TargetAlreadyExistsException(id, env, siteName);
+		}
+		createConfigFromTemplate(env, siteName, id, templateName, templateParams, configFile);
 
-        return resolveTargetFromConfigFile(configFile, LoadMode.CREATE);
-    }
+		return resolveTargetFromConfigFile(configFile, LoadMode.CREATE);
+	}
 
-    @Override
-    public synchronized void deleteTarget(String env, String siteName) throws TargetNotFoundException,
-            TargetServiceException {
-        Target target = getTarget(env, siteName);
-        String id = target.getId();
+	@Override
+	public synchronized void deleteTarget(String env, String siteName) throws TargetNotFoundException,
+			TargetServiceException {
+		Target target = getTarget(env, siteName);
+		String id = target.getId();
 
-        logger.info("Removing loaded target '{}'", id);
+		logger.info("Removing loaded target '{}'", id);
 
-        currentTargets.remove(target);
+		currentTargets.remove(target);
 
-        target.delete();
+		target.delete();
 
-        cleanupTarget(id, target.getConfigurationFile());
-    }
+		cleanupTarget(id, target.getConfigurationFile());
+	}
 
-    private void cleanupTarget(String targetId, File configFile) throws TargetServiceException {
-        try {
-            processedCommitsStore.delete(targetId);
-        } catch (DeployerException e) {
-            throw new TargetServiceException(format("Error while deleting processed commit from store for target '%s'", targetId), e);
-        }
-        if (configFile.exists()) {
-            logger.info("Deleting target configuration file at '{}'", configFile);
+	private void cleanupTarget(String targetId, File configFile) throws TargetServiceException {
+		try {
+			processedCommitsStore.delete(targetId);
+		} catch (DeployerException e) {
+			throw new TargetServiceException(format("Error while deleting processed commit from store for target '%s'", targetId), e);
+		}
+		if (configFile.exists()) {
+			logger.info("Deleting target configuration file at '{}'", configFile);
 
-            FileUtils.deleteQuietly(configFile);
-        }
+			FileUtils.deleteQuietly(configFile);
+		}
 
-        File contextFile = new File(targetConfigFolder, format(APPLICATION_CONTEXT_FILENAME_FORMAT,
-                configFile.getName()));
-        if (contextFile.exists()) {
-            logger.info("Deleting target context file at '{}'", contextFile);
+		File contextFile = new File(targetConfigFolder, format(APPLICATION_CONTEXT_FILENAME_FORMAT,
+				configFile.getName()));
+		if (contextFile.exists()) {
+			logger.info("Deleting target context file at '{}'", contextFile);
 
-            FileUtils.deleteQuietly(contextFile);
-        }
-        processorStateStore.delete(targetId);
-    }
+			FileUtils.deleteQuietly(contextFile);
+		}
+		processorStateStore.delete(targetId);
+	}
 
-    @Override
+	@Override
 	public void recreateIndex(String env, String siteName) throws TargetNotFoundException, ConfigurationException {
 		Target target = getTarget(env, siteName);
 		ApplicationContext appContext = target.getApplicationContext();

--- a/src/main/java/org/craftercms/deployer/impl/TargetServiceImpl.java
+++ b/src/main/java/org/craftercms/deployer/impl/TargetServiceImpl.java
@@ -82,207 +82,210 @@ import static org.craftercms.deployer.impl.DeploymentConstants.*;
 @Component("targetService")
 @DependsOn("crafter.cacheStoreAdapter")
 public class TargetServiceImpl implements TargetService, ApplicationListener<ApplicationReadyEvent>,
-		InitializingBean, DisposableBean {
+        InitializingBean, DisposableBean {
 
-	private static final Logger logger = LoggerFactory.getLogger(TargetServiceImpl.class);
+    private static final Logger logger = LoggerFactory.getLogger(TargetServiceImpl.class);
 
-	public static final String YAML_FILE_EXTENSION = "yaml";
-	public static final String APPLICATION_CONTEXT_FILENAME_FORMAT = "%s-context.xml";
-	public static final String CONFIG_PROPERTY_SOURCE_NAME = "targetConfig";
-	public static final String CONFIG_BEAN_NAME = "targetConfig";
+    public static final String YAML_FILE_EXTENSION = "yaml";
+    public static final String APPLICATION_CONTEXT_FILENAME_FORMAT = "%s-context.xml";
+    public static final String CONFIG_PROPERTY_SOURCE_NAME = "targetConfig";
+    public static final String CONFIG_BEAN_NAME = "targetConfig";
 
-	public static final String TARGET_ENV_MODEL_KEY = "env";
-	public static final String TARGET_SITE_NAME_MODEL_KEY = "site_name";
-	public static final String TARGET_SOURCE_TARGET_MODEL_KEY = "source_target";
-	public static final String TARGET_ID_MODEL_KEY = "target_id";
+    public static final String TARGET_ENV_MODEL_KEY = "env";
+    public static final String TARGET_SITE_NAME_MODEL_KEY = "site_name";
+    public static final String TARGET_SOURCE_TARGET_MODEL_KEY = "source_target";
+    public static final String TARGET_ID_MODEL_KEY = "target_id";
 
-	protected final File targetConfigFolder;
-	protected final Resource baseTargetYamlConfigResource;
-	protected final Resource baseTargetYamlConfigOverrideResource;
-	protected final Resource baseTargetContextResource;
-	protected final Resource baseTargetContextOverrideResource;
-	protected final String defaultTargetConfigTemplateName;
-	protected final Handlebars targetConfigTemplateEngine;
-	protected final ApplicationContext mainApplicationContext;
-	protected final DeploymentPipelineFactory deploymentPipelineFactory;
-	protected final TaskScheduler taskScheduler;
-	protected final ExecutorService taskExecutor;
-	protected final ProcessedCommitsStore processedCommitsStore;
-	protected final ProcessorStateStore processorStateStore;
-	protected final TargetLifecycleHooksResolver targetLifecycleHooksResolver;
-	protected final EncryptionAwareConfigurationReader configurationReader;
-	protected final UpgradeManager<Target> upgradeManager;
-	protected final Set<Target> currentTargets;
+    protected final File targetConfigFolder;
+    protected final Resource baseTargetYamlConfigResource;
+    protected final Resource baseTargetYamlConfigOverrideResource;
+    protected final Resource baseTargetContextResource;
+    protected final Resource baseTargetContextOverrideResource;
+    protected final String defaultTargetConfigTemplateName;
+    protected final Handlebars targetConfigTemplateEngine;
+    protected final ApplicationContext mainApplicationContext;
+    protected final DeploymentPipelineFactory deploymentPipelineFactory;
+    protected final TaskScheduler taskScheduler;
+    protected final ExecutorService taskExecutor;
+    protected final ProcessedCommitsStore processedCommitsStore;
+    protected final ProcessorStateStore processorStateStore;
+    protected final TargetLifecycleHooksResolver targetLifecycleHooksResolver;
+    protected final EncryptionAwareConfigurationReader configurationReader;
+    protected final UpgradeManager<Target> upgradeManager;
+    protected final Set<Target> currentTargets;
+    protected final int maxTargetInitRetryAttempts;
 
-	public TargetServiceImpl(
-			@Value("${deployer.main.targets.config.folderPath}") File targetConfigFolder,
-			@Value("${deployer.main.targets.config.baseYaml.location}") Resource baseTargetYamlConfigResource,
-			@Value("${deployer.main.targets.config.baseYaml.overrideLocation}") Resource baseTargetYamlConfigOverrideResource,
-			@Value("${deployer.main.targets.config.baseContext.location}") Resource baseTargetContextResource,
-			@Value("${deployer.main.targets.config.baseContext.overrideLocation}") Resource baseTargetContextOverrideResource,
-			@Value("${deployer.main.targets.config.templates.default}") String defaultTargetConfigTemplateName,
-			@Autowired Handlebars targetConfigTemplateEngine,
-			@Autowired ApplicationContext mainApplicationContext,
-			@Autowired DeploymentPipelineFactory deploymentPipelineFactory,
-			@Autowired TaskScheduler taskScheduler,
-			@Autowired ExecutorService taskExecutor,
-			@Autowired ProcessedCommitsStore processedCommitsStore,
-			@Autowired ProcessorStateStore processorStateStore,
-			@Autowired TargetLifecycleHooksResolver targetLifecycleHooksResolver,
-			@Autowired EncryptionAwareConfigurationReader configurationReader,
-			@Autowired UpgradeManager<Target> upgradeManager) {
-		this.targetConfigFolder = targetConfigFolder;
-		this.baseTargetYamlConfigResource = baseTargetYamlConfigResource;
-		this.baseTargetYamlConfigOverrideResource = baseTargetYamlConfigOverrideResource;
-		this.baseTargetContextResource = baseTargetContextResource;
-		this.baseTargetContextOverrideResource = baseTargetContextOverrideResource;
-		this.defaultTargetConfigTemplateName = defaultTargetConfigTemplateName;
-		this.targetConfigTemplateEngine = targetConfigTemplateEngine;
-		this.mainApplicationContext = mainApplicationContext;
-		this.deploymentPipelineFactory = deploymentPipelineFactory;
-		this.taskScheduler = taskScheduler;
-		this.taskExecutor = taskExecutor;
-		this.processedCommitsStore = processedCommitsStore;
-		this.processorStateStore = processorStateStore;
-		this.targetLifecycleHooksResolver = targetLifecycleHooksResolver;
-		this.configurationReader = configurationReader;
-		this.upgradeManager = upgradeManager;
-		this.currentTargets = new CopyOnWriteArraySet<>();
-	}
+    public TargetServiceImpl(
+            @Value("${deployer.main.targets.config.folderPath}") File targetConfigFolder,
+            @Value("${deployer.main.targets.config.baseYaml.location}") Resource baseTargetYamlConfigResource,
+            @Value("${deployer.main.targets.config.baseYaml.overrideLocation}") Resource baseTargetYamlConfigOverrideResource,
+            @Value("${deployer.main.targets.config.baseContext.location}") Resource baseTargetContextResource,
+            @Value("${deployer.main.targets.config.baseContext.overrideLocation}") Resource baseTargetContextOverrideResource,
+            @Value("${deployer.main.targets.config.templates.default}") String defaultTargetConfigTemplateName,
+            @Value("${deployer.main.targets.maxInitRetries}") int maxTargetInitRetryAttempts,
+            @Autowired Handlebars targetConfigTemplateEngine,
+            @Autowired ApplicationContext mainApplicationContext,
+            @Autowired DeploymentPipelineFactory deploymentPipelineFactory,
+            @Autowired TaskScheduler taskScheduler,
+            @Autowired ExecutorService taskExecutor,
+            @Autowired ProcessedCommitsStore processedCommitsStore,
+            @Autowired ProcessorStateStore processorStateStore,
+            @Autowired TargetLifecycleHooksResolver targetLifecycleHooksResolver,
+            @Autowired EncryptionAwareConfigurationReader configurationReader,
+            @Autowired UpgradeManager<Target> upgradeManager) {
+        this.targetConfigFolder = targetConfigFolder;
+        this.baseTargetYamlConfigResource = baseTargetYamlConfigResource;
+        this.baseTargetYamlConfigOverrideResource = baseTargetYamlConfigOverrideResource;
+        this.baseTargetContextResource = baseTargetContextResource;
+        this.baseTargetContextOverrideResource = baseTargetContextOverrideResource;
+        this.defaultTargetConfigTemplateName = defaultTargetConfigTemplateName;
+        this.targetConfigTemplateEngine = targetConfigTemplateEngine;
+        this.mainApplicationContext = mainApplicationContext;
+        this.deploymentPipelineFactory = deploymentPipelineFactory;
+        this.taskScheduler = taskScheduler;
+        this.taskExecutor = taskExecutor;
+        this.processedCommitsStore = processedCommitsStore;
+        this.processorStateStore = processorStateStore;
+        this.targetLifecycleHooksResolver = targetLifecycleHooksResolver;
+        this.configurationReader = configurationReader;
+        this.upgradeManager = upgradeManager;
+        this.currentTargets = new CopyOnWriteArraySet<>();
+        this.maxTargetInitRetryAttempts = maxTargetInitRetryAttempts;
+    }
 
-	public void afterPropertiesSet() throws DeployerException {
-		if (targetConfigFolder.exists()) {
-			return;
-		}
-		logger.info("Target config folder '{}' doesn't exist. Creating it", targetConfigFolder);
+    public void afterPropertiesSet() throws DeployerException {
+        if (targetConfigFolder.exists()) {
+            return;
+        }
+        logger.info("Target config folder '{}' doesn't exist. Creating it", targetConfigFolder);
 
-		try {
-			FileUtils.forceMkdir(targetConfigFolder);
-		} catch (IOException e) {
-			throw new DeployerException(format("Failed to create target config folder at '%s'", targetConfigFolder));
-		}
-	}
+        try {
+            FileUtils.forceMkdir(targetConfigFolder);
+        } catch (IOException e) {
+            throw new DeployerException(format("Failed to create target config folder at '%s'", targetConfigFolder));
+        }
+    }
 
-	@Override
-	public void onApplicationEvent(@NonNull ApplicationReadyEvent event) {
-		// Load all existing targets on startup
-		try {
-			List<Target> targets = resolveTargets();
-			if (CollectionUtils.isEmpty(targets)) {
-				logger.warn("No config files found under '{}'", targetConfigFolder.getAbsolutePath());
-			} else {
-				// check if there are any targets that need to be unlocked
-				targets.forEach(Target::unlock);
-			}
-		} catch (DeployerException e) {
-			logger.error("Error while loading targets on startup", e);
-		}
-	}
+    @Override
+    public void onApplicationEvent(@NonNull ApplicationReadyEvent event) {
+        // Load all existing targets on startup
+        try {
+            List<Target> targets = resolveTargets();
+            if (CollectionUtils.isEmpty(targets)) {
+                logger.warn("No config files found under '{}'", targetConfigFolder.getAbsolutePath());
+            } else {
+                // check if there are any targets that need to be unlocked
+                targets.forEach(Target::unlock);
+            }
+        } catch (DeployerException e) {
+            logger.error("Error while loading targets on startup", e);
+        }
+    }
 
-	@Override
-	public void destroy() {
-		logger.info("Closing all targets...");
+    @Override
+    public void destroy() {
+        logger.info("Closing all targets...");
 
-		if (isNotEmpty(currentTargets)) {
-			currentTargets.forEach(Target::close);
-		}
-	}
+        if (isNotEmpty(currentTargets)) {
+            currentTargets.forEach(Target::close);
+        }
+    }
 
-	@Override
-	public List<Target> getAllTargets() {
-		return new ArrayList<>(currentTargets);
-	}
+    @Override
+    public List<Target> getAllTargets() {
+        return new ArrayList<>(currentTargets);
+    }
 
-	@Override
-	public boolean targetExists(String env, String siteName) {
-		String id = TargetImpl.getId(env, siteName);
+    @Override
+    public boolean targetExists(String env, String siteName) {
+        String id = TargetImpl.getId(env, siteName);
 
-		return findLoadedTargetById(id) != null;
-	}
+        return findLoadedTargetById(id) != null;
+    }
 
-	@Override
-	public Target getTarget(String env, String siteName) throws TargetNotFoundException {
-		String id = TargetImpl.getId(env, siteName);
-		Target target = findLoadedTargetById(id);
+    @Override
+    public Target getTarget(String env, String siteName) throws TargetNotFoundException {
+        String id = TargetImpl.getId(env, siteName);
+        Target target = findLoadedTargetById(id);
 
-		if (target != null) {
-			return target;
-		}
-		throw new TargetNotFoundException(id, env, siteName);
-	}
+        if (target != null) {
+            return target;
+        }
+        throw new TargetNotFoundException(id, env, siteName);
+    }
 
-	@Override
-	public synchronized List<Target> resolveTargets() throws TargetServiceException {
-		Collection<File> configFiles = getTargetConfigFiles();
-		List<Target> targets = new ArrayList<>();
+    @Override
+    public synchronized List<Target> resolveTargets() throws TargetServiceException {
+        Collection<File> configFiles = getTargetConfigFiles();
+        List<Target> targets = new ArrayList<>();
 
-		if (!isNotEmpty(configFiles)) {
-			return targets;
-		}
-		closeTargetsWithNoConfigFile(configFiles);
+        if (!isNotEmpty(configFiles)) {
+            return targets;
+        }
+        closeTargetsWithNoConfigFile(configFiles);
 
-		for (File file : configFiles) {
-			Target target = resolveTargetFromConfigFile(file, LoadMode.LOAD);
-			targets.add(target);
-		}
+        for (File file : configFiles) {
+            Target target = resolveTargetFromConfigFile(file, LoadMode.LOAD);
+            targets.add(target);
+        }
 
-		return targets;
-	}
+        return targets;
+    }
 
-	@Override
-	public synchronized Target createTarget(String env, String siteName, boolean replace, String templateName,
-											Map<String, Object> templateParams)
-			throws TargetAlreadyExistsException,
-			TargetServiceException {
-		String id = TargetImpl.getId(env, siteName);
-		File configFile = new File(targetConfigFolder, id + "." + YAML_FILE_EXTENSION);
+    @Override
+    public synchronized Target createTarget(String env, String siteName, boolean replace, String templateName,
+                                            Map<String, Object> templateParams)
+            throws TargetAlreadyExistsException,
+            TargetServiceException {
+        String id = TargetImpl.getId(env, siteName);
+        File configFile = new File(targetConfigFolder, id + "." + YAML_FILE_EXTENSION);
 
-		if (!replace && configFile.exists()) {
-			throw new TargetAlreadyExistsException(id, env, siteName);
-		}
-		createConfigFromTemplate(env, siteName, id, templateName, templateParams, configFile);
+        if (!replace && configFile.exists()) {
+            throw new TargetAlreadyExistsException(id, env, siteName);
+        }
+        createConfigFromTemplate(env, siteName, id, templateName, templateParams, configFile);
 
-		return resolveTargetFromConfigFile(configFile, LoadMode.CREATE);
-	}
+        return resolveTargetFromConfigFile(configFile, LoadMode.CREATE);
+    }
 
-	@Override
-	public synchronized void deleteTarget(String env, String siteName) throws TargetNotFoundException,
-			TargetServiceException {
-		Target target = getTarget(env, siteName);
-		String id = target.getId();
+    @Override
+    public synchronized void deleteTarget(String env, String siteName) throws TargetNotFoundException,
+            TargetServiceException {
+        Target target = getTarget(env, siteName);
+        String id = target.getId();
 
-		logger.info("Removing loaded target '{}'", id);
+        logger.info("Removing loaded target '{}'", id);
 
-		currentTargets.remove(target);
+        currentTargets.remove(target);
 
-		target.delete();
+        target.delete();
 
-		cleanupTarget(id, target.getConfigurationFile());
-	}
+        cleanupTarget(id, target.getConfigurationFile());
+    }
 
-	private void cleanupTarget(String targetId, File configFile) throws TargetServiceException {
-		try {
-			processedCommitsStore.delete(targetId);
-		} catch (DeployerException e) {
-			throw new TargetServiceException(format("Error while deleting processed commit from store for target '%s'", targetId), e);
-		}
-		if (configFile.exists()) {
-			logger.info("Deleting target configuration file at '{}'", configFile);
+    private void cleanupTarget(String targetId, File configFile) throws TargetServiceException {
+        try {
+            processedCommitsStore.delete(targetId);
+        } catch (DeployerException e) {
+            throw new TargetServiceException(format("Error while deleting processed commit from store for target '%s'", targetId), e);
+        }
+        if (configFile.exists()) {
+            logger.info("Deleting target configuration file at '{}'", configFile);
 
-			FileUtils.deleteQuietly(configFile);
-		}
+            FileUtils.deleteQuietly(configFile);
+        }
 
-		File contextFile = new File(targetConfigFolder, format(APPLICATION_CONTEXT_FILENAME_FORMAT,
-				configFile.getName()));
-		if (contextFile.exists()) {
-			logger.info("Deleting target context file at '{}'", contextFile);
+        File contextFile = new File(targetConfigFolder, format(APPLICATION_CONTEXT_FILENAME_FORMAT,
+                configFile.getName()));
+        if (contextFile.exists()) {
+            logger.info("Deleting target context file at '{}'", contextFile);
 
-			FileUtils.deleteQuietly(contextFile);
-		}
-		processorStateStore.delete(targetId);
-	}
+            FileUtils.deleteQuietly(contextFile);
+        }
+        processorStateStore.delete(targetId);
+    }
 
-	@Override
+    @Override
 	public void recreateIndex(String env, String siteName) throws TargetNotFoundException, ConfigurationException {
 		Target target = getTarget(env, siteName);
 		ApplicationContext appContext = target.getApplicationContext();
@@ -351,32 +354,41 @@ public class TargetServiceImpl implements TargetService, ApplicationListener<App
 		String baseName = FilenameUtils.getBaseName(configFile.getName());
 		File contextFile = new File(targetConfigFolder, format(APPLICATION_CONTEXT_FILENAME_FORMAT, baseName));
 		Target target = findLoadedTargetByConfigFile(configFile);
+		int targetInitRetryAttempts;
 
 		if (target != null) {
 			// Check if the YAML config file or the app context file have changed since target load.
 			long yamlLastModified = configFile.exists() ? configFile.lastModified() : 0;
 			long contextLastModified = contextFile.exists() ? contextFile.lastModified() : 0;
 			long targetLoadedDate = target.getLoadDate().toInstant().toEpochMilli();
+			targetInitRetryAttempts = target.getInitRetryAttempts();
 
 			// Refresh if the files have been modified.
 			if (yamlLastModified >= targetLoadedDate || contextLastModified >= targetLoadedDate) {
 				logger.info("Configuration files haven been updated for '{}'. The target will be reloaded.",
 						target.getId());
-
 				target.close();
-
 				currentTargets.remove(target);
-
 				target = null;
+			} else if (target.getStatus() == Target.Status.INIT_FAILED) {
+				if (targetInitRetryAttempts > 0) {
+					logger.info("Target '{}' is in INIT_FAILED state. Reloading target. {} attempts left", target.getId(), targetInitRetryAttempts);
+					target.close();
+					currentTargets.remove(target);
+					target = null;
+				} else {
+					logger.error("Target '{}' is in INIT_FAILED state and has no retry attempts left. Not reloading target.", target.getId());
+				}
 			}
 		} else {
+			targetInitRetryAttempts = maxTargetInitRetryAttempts;
 			logger.info("No loaded target found for configuration file {}", configFile);
 		}
 
 		if (target == null) {
 			logger.info("Loading target for configuration file {}", configFile);
 
-			target = loadTarget(configFile, contextFile, loadMode);
+			target = loadTarget(configFile, contextFile, loadMode, targetInitRetryAttempts);
 			currentTargets.add(target);
 		}
 
@@ -398,7 +410,8 @@ public class TargetServiceImpl implements TargetService, ApplicationListener<App
 		return context.getBean(TargetImpl.class);
 	}
 
-	protected Target loadTarget(File configFile, File contextFile, LoadMode loadMode) throws TargetServiceException {
+	protected Target loadTarget(File configFile, File contextFile, LoadMode loadMode, int retryAttempts)
+			throws TargetServiceException {
 		try {
 			// Create the target temporarily to run upgrades
 			TargetImpl target = buildTarget(configFile, contextFile);
@@ -413,6 +426,7 @@ public class TargetServiceImpl implements TargetService, ApplicationListener<App
 				case DUPLICATE -> target.executeDuplicateHooks();
 			}
 
+			target.setInitRetryAttempts(retryAttempts);
 			startInit(target);
 
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -42,6 +42,8 @@ deployer:
             # The max maxAliasesForCollections for yaml files
             yamlMaxAliasesForCollections: 1
         targets:
+            # Maximum number of retries to initialize targets
+            maxInitRetries: 10
             config:
                 # The folder path for target configuration files
                 folderPath: ${targets.dir}

--- a/src/test/java/org/craftercms/deployer/impl/TargetServiceImplTest.java
+++ b/src/test/java/org/craftercms/deployer/impl/TargetServiceImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2024 Crafter Software Corporation. All Rights Reserved.
+ * Copyright (C) 2007-2025 Crafter Software Corporation. All Rights Reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as published by
@@ -123,6 +123,7 @@ public class TargetServiceImplTest {
 				new ClassPathResource("test-base-target-context.xml"),
 				new ClassPathResource("test-base-target-context-override.xml"),
 				"test",
+				10,
 				createHandlebars(),
 				context,
 				deploymentPipelineFactory,

--- a/src/test/java/org/craftercms/deployer/impl/TargetServiceImplTest.java
+++ b/src/test/java/org/craftercms/deployer/impl/TargetServiceImplTest.java
@@ -117,22 +117,22 @@ public class TargetServiceImplTest {
 		context.refresh();
 
 		targetService = new TargetServiceImpl(
-			targetsFolder,
-			new ClassPathResource("test-base-target.yaml"),
-			new ClassPathResource("test-base-target-override.yaml"),
-			new ClassPathResource("test-base-target-context.xml"),
-			new ClassPathResource("test-base-target-context-override.xml"),
-			"test",
-			createHandlebars(),
-			context,
-			deploymentPipelineFactory,
-			taskScheduler,
-			taskExecutor,
-			processedCommitsStore,
-			processorStateStore,
-			targetLifecycleHooksResolver,
-			createConfigurationReader(),
-			createUpgradeManager());
+				targetsFolder,
+				new ClassPathResource("test-base-target.yaml"),
+				new ClassPathResource("test-base-target-override.yaml"),
+				new ClassPathResource("test-base-target-context.xml"),
+				new ClassPathResource("test-base-target-context-override.xml"),
+				"test",
+				createHandlebars(),
+				context,
+				deploymentPipelineFactory,
+				taskScheduler,
+				taskExecutor,
+				processedCommitsStore,
+				processorStateStore,
+				targetLifecycleHooksResolver,
+				createConfigurationReader(),
+				createUpgradeManager());
 	}
 
 	@After
@@ -301,7 +301,7 @@ public class TargetServiceImplTest {
 		TargetService targetServiceSpy = Mockito.spy(targetService);
 		doReturn(false).when(targetServiceSpy).targetExists(ENVIRONMENT, NON_EXISTING_SITE);
 		assertThrows(TargetNotFoundException.class,
-			() -> targetServiceSpy.duplicateTarget(ENVIRONMENT, NON_EXISTING_SITE, NEW_SITE_NAME, false, "test", emptyMap()));
+				() -> targetServiceSpy.duplicateTarget(ENVIRONMENT, NON_EXISTING_SITE, NEW_SITE_NAME, false, "test", emptyMap()));
 	}
 
 	@Test
@@ -310,7 +310,7 @@ public class TargetServiceImplTest {
 		when(targetServiceSpy.targetExists(ENVIRONMENT, EXISTING_SITE)).thenReturn(true);
 
 		assertThrows(TargetAlreadyExistsException.class,
-			() -> targetServiceSpy.duplicateTarget(ENVIRONMENT, SOURCE_SITE_NAME, EXISTING_SITE, false, "test", emptyMap()));
+				() -> targetServiceSpy.duplicateTarget(ENVIRONMENT, SOURCE_SITE_NAME, EXISTING_SITE, false, "test", emptyMap()));
 	}
 
 	@Test
@@ -433,7 +433,7 @@ public class TargetServiceImplTest {
 	}
 
 	private DeploymentPipelineFactory createDeploymentPipelineFactory() throws ConfigurationException,
-		DeployerException {
+			DeployerException {
 		DeploymentPipelineFactory pipelineFactory = mock(DeploymentPipelineFactory.class);
 		when(pipelineFactory.getPipeline(any(), any(), anyString())).thenReturn(mock(DeploymentPipeline.class));
 
@@ -453,7 +453,7 @@ public class TargetServiceImplTest {
 	}
 
 	private TargetLifecycleHooksResolver createTargetLifecycleHooksResolver() throws ConfigurationException,
-		DeployerException {
+			DeployerException {
 		createHooks = Collections.singletonList(mock(TargetLifecycleHook.class));
 
 		TargetLifecycleHooksResolver resolver = mock(TargetLifecycleHooksResolver.class);


### PR DESCRIPTION
Retry targets when init has failed. Limit the number of attempts for target init
https://github.com/craftersoftware/craftercms/issues/1143

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a configurable retry mechanism for target initialization failures, allowing targets to retry initialization up to a specified maximum number of attempts.
  * Added a new setting to configure the maximum number of initialization retries for targets.

* **Chores**
  * Updated copyright year in test files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->