### PR TITLE
Make search connection pool configurable

### DIFF
--- a/src/main/java/org/craftercms/deployer/utils/opensearch/OpenSearchClusterConfig.java
+++ b/src/main/java/org/craftercms/deployer/utils/opensearch/OpenSearchClusterConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2022 Crafter Software Corporation. All Rights Reserved.
+ * Copyright (C) 2007-2025 Crafter Software Corporation. All Rights Reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -44,6 +44,10 @@ public class OpenSearchClusterConfig {
 
 	public static final String CONFIG_KEY_KEEP_ALIVE = "keepAlive";
 
+	public static final String CONFIG_KEY_MAX_TOTAL_CONNECTIONS = "maxTotalConnections";
+
+	public static final String CONFIG_KEY_MAX_CONNECTIONS_PER_ROUTE = "maxConnectionsPerRoute";
+
 	/**
 	 * The list of urls to connect to the cluster
 	 */
@@ -67,6 +71,10 @@ public class OpenSearchClusterConfig {
 
 	public final boolean keepAlive;
 
+	public final int maxTotalConnections;
+
+	public final int maxConnectionsPerRoute;
+
 	public OpenSearchClusterConfig() {
 		urls = null;
 		username = null;
@@ -75,6 +83,8 @@ public class OpenSearchClusterConfig {
 		socketTimeout = -1;
 		threadCount = -1;
 		keepAlive = false;
+		maxTotalConnections = -1;
+		maxConnectionsPerRoute = -1;
 	}
 
 	public OpenSearchClusterConfig(HierarchicalConfiguration<?> config) {
@@ -85,10 +95,13 @@ public class OpenSearchClusterConfig {
 		socketTimeout = config.getInt(CONFIG_KEY_TIMEOUT_SOCKET, -1);
 		threadCount = config.getInt(CONFIG_KEY_THREADS, -1);
 		keepAlive = config.getBoolean(CONFIG_KEY_KEEP_ALIVE, false);
+		maxTotalConnections = config.getInt(CONFIG_KEY_MAX_TOTAL_CONNECTIONS, -1);
+		maxConnectionsPerRoute = config.getInt(CONFIG_KEY_MAX_CONNECTIONS_PER_ROUTE, -1);
 	}
 
 	public OpenSearchClusterConfig(HierarchicalConfiguration<?> config, String username, String password,
-				       int connectTimeout, int socketTimeout, int threadCount, boolean keepAlive) {
+								   int connectTimeout, int socketTimeout, int threadCount, boolean keepAlive,
+								   int maxTotalConnections, int maxConnectionsPerRoute) {
 		urls = (String[]) config.getArray(String.class, CONFIG_KEY_URLS);
 		this.username = config.getString(CONFIG_KEY_USERNAME, username);
 		this.password = config.getString(CONFIG_KEY_PASSWORD, password);
@@ -96,13 +109,15 @@ public class OpenSearchClusterConfig {
 		this.socketTimeout = config.getInt(CONFIG_KEY_TIMEOUT_SOCKET, socketTimeout);
 		this.threadCount = config.getInt(CONFIG_KEY_THREADS, threadCount);
 		this.keepAlive = config.getBoolean(CONFIG_KEY_KEEP_ALIVE, keepAlive);
+		this.maxTotalConnections = config.getInt(CONFIG_KEY_MAX_TOTAL_CONNECTIONS, maxTotalConnections);
+		this.maxConnectionsPerRoute = config.getInt(CONFIG_KEY_MAX_CONNECTIONS_PER_ROUTE, maxConnectionsPerRoute);
 	}
 
 	/**
 	 * Returns a client matching the current configuration of the cluster
 	 */
 	public OpenSearchClient buildClient() {
-		return createClient(urls, username, password, connectTimeout, socketTimeout, threadCount, keepAlive);
+		return createClient(urls, username, password, connectTimeout, socketTimeout, threadCount, keepAlive, maxTotalConnections, maxConnectionsPerRoute);
 	}
 
 }

--- a/src/main/java/org/craftercms/deployer/utils/opensearch/OpenSearchConfig.java
+++ b/src/main/java/org/craftercms/deployer/utils/opensearch/OpenSearchConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2022 Crafter Software Corporation. All Rights Reserved.
+ * Copyright (C) 2007-2025 Crafter Software Corporation. All Rights Reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,14 +17,14 @@
 
 package org.craftercms.deployer.utils.opensearch;
 
+import org.apache.commons.configuration2.Configuration;
+import org.apache.commons.configuration2.HierarchicalConfiguration;
+import org.apache.commons.lang3.ArrayUtils;
+
 import java.beans.ConstructorProperties;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import org.apache.commons.configuration2.Configuration;
-import org.apache.commons.configuration2.HierarchicalConfiguration;
-import org.apache.commons.lang3.ArrayUtils;
 
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.collections4.CollectionUtils.isEmpty;
@@ -82,17 +82,18 @@ public class OpenSearchConfig {
 		}
 		if (!isEmpty(config.childConfigurationsAt(CONFIG_KEY_READ_CLUSTER))) {
 			readCluster = new OpenSearchClusterConfig(config.configurationAt(CONFIG_KEY_READ_CLUSTER),
-				globalCluster.username, globalCluster.password, globalCluster.connectTimeout,
-				globalCluster.socketTimeout, globalCluster.threadCount, globalCluster.keepAlive);
+					globalCluster.username, globalCluster.password, globalCluster.connectTimeout,
+					globalCluster.socketTimeout, globalCluster.threadCount, globalCluster.keepAlive,
+					globalCluster.maxTotalConnections, globalCluster.maxConnectionsPerRoute);
 		} else {
 			readCluster = new OpenSearchClusterConfig();
 		}
 		writeClusters = config.configurationsAt(CONFIG_KEY_WRITE_CLUSTERS)
-			.stream()
-			.map(cluster -> new OpenSearchClusterConfig(cluster, globalCluster.username, globalCluster.password,
-				globalCluster.connectTimeout, globalCluster.socketTimeout, globalCluster.threadCount,
-				globalCluster.keepAlive))
-			.collect(toList());
+				.stream()
+				.map(cluster -> new OpenSearchClusterConfig(cluster, globalCluster.username, globalCluster.password,
+						globalCluster.connectTimeout, globalCluster.socketTimeout, globalCluster.threadCount,
+						globalCluster.keepAlive, globalCluster.maxTotalConnections, globalCluster.maxConnectionsPerRoute))
+				.collect(toList());
 		if (useSingleCluster() && ArrayUtils.isEmpty(globalCluster.urls)) {
 			throw new IllegalStateException("Invalid OpenSearch configuration");
 		}
@@ -102,7 +103,7 @@ public class OpenSearchConfig {
 
 		indexSettings = new HashMap<>();
 		config.configurationsAt(CONFIG_KEY_INDEX_SETTINGS).forEach(settingConfig ->
-			indexSettings.put(settingConfig.getString(CONFIG_KEY_KEY), settingConfig.getString(CONFIG_KEY_VALUE)));
+				indexSettings.put(settingConfig.getString(CONFIG_KEY_KEY), settingConfig.getString(CONFIG_KEY_VALUE)));
 	}
 
 	/**

--- a/src/main/java/org/craftercms/deployer/utils/opensearch/legacy/OpenSearchClusterConfig.java
+++ b/src/main/java/org/craftercms/deployer/utils/opensearch/legacy/OpenSearchClusterConfig.java
@@ -44,6 +44,10 @@ public class OpenSearchClusterConfig {
 
 	public static final String CONFIG_KEY_KEEP_ALIVE = "keepAlive";
 
+	public static final String CONFIG_KEY_MAX_TOTAL_CONNECTIONS = "maxTotalConnections";
+
+	public static final String CONFIG_KEY_MAX_CONNECTIONS_PER_ROUTE = "maxConnectionsPerRoute";
+
 	/**
 	 * The list of urls to connect to the cluster
 	 */
@@ -67,6 +71,10 @@ public class OpenSearchClusterConfig {
 
 	public final boolean keepAlive;
 
+	public final int maxTotalConnections;
+
+	public final int maxConnectionsPerRoute;
+
 	public OpenSearchClusterConfig() {
 		urls = null;
 		username = null;
@@ -75,6 +83,8 @@ public class OpenSearchClusterConfig {
 		socketTimeout = -1;
 		threadCount = -1;
 		keepAlive = false;
+		maxTotalConnections = -1;
+		maxConnectionsPerRoute = -1;
 	}
 
 	public OpenSearchClusterConfig(HierarchicalConfiguration<?> config) {
@@ -85,10 +95,13 @@ public class OpenSearchClusterConfig {
 		socketTimeout = config.getInt(CONFIG_KEY_TIMEOUT_SOCKET, -1);
 		threadCount = config.getInt(CONFIG_KEY_THREADS, -1);
 		keepAlive = config.getBoolean(CONFIG_KEY_KEEP_ALIVE, false);
+		maxTotalConnections = config.getInt(CONFIG_KEY_MAX_TOTAL_CONNECTIONS, -1);
+		maxConnectionsPerRoute = config.getInt(CONFIG_KEY_MAX_CONNECTIONS_PER_ROUTE, -1);
 	}
 
 	public OpenSearchClusterConfig(HierarchicalConfiguration<?> config, String username, String password,
-				       int connectTimeout, int socketTimeout, int threadCount, boolean keepAlive) {
+								   int connectTimeout, int socketTimeout, int threadCount, boolean keepAlive,
+								   int maxTotalConnections, int maxConnectionsPerRoute) {
 		urls = (String[]) config.getArray(String.class, CONFIG_KEY_URLS);
 		this.username = config.getString(CONFIG_KEY_USERNAME, username);
 		this.password = config.getString(CONFIG_KEY_PASSWORD, password);
@@ -96,13 +109,15 @@ public class OpenSearchClusterConfig {
 		this.socketTimeout = config.getInt(CONFIG_KEY_TIMEOUT_SOCKET, socketTimeout);
 		this.threadCount = config.getInt(CONFIG_KEY_THREADS, threadCount);
 		this.keepAlive = config.getBoolean(CONFIG_KEY_KEEP_ALIVE, keepAlive);
+		this.maxTotalConnections = config.getInt(CONFIG_KEY_MAX_TOTAL_CONNECTIONS, maxTotalConnections);
+		this.maxConnectionsPerRoute = config.getInt(CONFIG_KEY_MAX_CONNECTIONS_PER_ROUTE, maxConnectionsPerRoute);
 	}
 
 	/**
 	 * Returns a client matching the current configuration of the cluster
 	 */
 	public RestHighLevelClient buildClient() {
-		return createClient(urls, username, password, connectTimeout, socketTimeout, threadCount, keepAlive);
+		return createClient(urls, username, password, connectTimeout, socketTimeout, threadCount, keepAlive, maxTotalConnections, maxConnectionsPerRoute);
 	}
 
 }

--- a/src/main/java/org/craftercms/deployer/utils/opensearch/legacy/OpenSearchConfig.java
+++ b/src/main/java/org/craftercms/deployer/utils/opensearch/legacy/OpenSearchConfig.java
@@ -86,17 +86,18 @@ public class OpenSearchConfig {
 		}
 		if (!isEmpty(config.childConfigurationsAt(CONFIG_KEY_READ_CLUSTER))) {
 			readCluster = new OpenSearchClusterConfig(config.configurationAt(CONFIG_KEY_READ_CLUSTER),
-				globalCluster.username, globalCluster.password, globalCluster.connectTimeout,
-				globalCluster.socketTimeout, globalCluster.threadCount, globalCluster.keepAlive);
+					globalCluster.username, globalCluster.password, globalCluster.connectTimeout,
+					globalCluster.socketTimeout, globalCluster.threadCount, globalCluster.keepAlive,
+					globalCluster.maxTotalConnections, globalCluster.maxConnectionsPerRoute);
 		} else {
 			readCluster = new OpenSearchClusterConfig();
 		}
 		writeClusters = config.configurationsAt(CONFIG_KEY_WRITE_CLUSTERS)
-			.stream()
-			.map(cluster -> new OpenSearchClusterConfig(cluster, globalCluster.username, globalCluster.password,
-				globalCluster.connectTimeout, globalCluster.socketTimeout, globalCluster.threadCount,
-				globalCluster.keepAlive))
-			.collect(toList());
+				.stream()
+				.map(cluster -> new OpenSearchClusterConfig(cluster, globalCluster.username, globalCluster.password,
+						globalCluster.connectTimeout, globalCluster.socketTimeout, globalCluster.threadCount,
+						globalCluster.keepAlive, globalCluster.maxTotalConnections, globalCluster.maxConnectionsPerRoute))
+				.collect(toList());
 		if (useSingleCluster() && ArrayUtils.isEmpty(globalCluster.urls)) {
 			throw new IllegalStateException("Invalid OpenSearch configuration");
 		}
@@ -106,7 +107,7 @@ public class OpenSearchConfig {
 
 		indexSettings = new HashMap<>();
 		config.configurationsAt(CONFIG_KEY_INDEX_SETTINGS).forEach(settingConfig ->
-			indexSettings.put(settingConfig.getString(CONFIG_KEY_KEY), settingConfig.getString(CONFIG_KEY_VALUE)));
+				indexSettings.put(settingConfig.getString(CONFIG_KEY_KEY), settingConfig.getString(CONFIG_KEY_VALUE)));
 		ignoredSettings = new HashSet<>(Arrays.asList(config.getStringArray(CONFIG_KEY_IGNORED_INDEX_SETTINGS)));
 
 		reindexSlices = config.getInt(CONFIG_KEY_REINDEX_SLICES);


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/8344
Make search connection pool configurable

Notice this PR is dependent on https://github.com/craftercms/search/pull/348

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added configuration options to control OpenSearch connection pooling: max total connections and per‑route limits, improving stability and throughput under load.
  - Introduced locale mapping configuration to better handle language-specific indexing and searches.
  - Added configurable timeout for reindex operations to avoid long-running tasks.
  - These settings are available for both current and legacy OpenSearch configurations and default to backward‑compatible values, requiring no changes unless you opt in.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->