### PR TITLE
Return 503 (instead of 500) when trying to deploy a target that is no ready

### DIFF
--- a/src/main/api/deployer-api.yaml
+++ b/src/main/api/deployer-api.yaml
@@ -277,6 +277,8 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
 
   /api/1/target/deploy-all:
     post:
@@ -1039,6 +1041,16 @@ components:
               message:
                 type: string
                 example: Internal Server Error
+    ServiceUnavailable:
+      description: Service unavailable
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+                example: Not available
 
     Accepted:
       description: Accepted

--- a/src/main/java/org/craftercms/deployer/api/DeploymentService.java
+++ b/src/main/java/org/craftercms/deployer/api/DeploymentService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2022 Crafter Software Corporation. All Rights Reserved.
+ * Copyright (C) 2007-2026 Crafter Software Corporation. All Rights Reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as published by
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import org.craftercms.deployer.api.exceptions.DeploymentServiceException;
 import org.craftercms.deployer.api.exceptions.TargetNotFoundException;
+import org.craftercms.deployer.api.exceptions.TargetNotReadyException;
 
 /**
  * Service for doing deployments.
@@ -52,6 +53,6 @@ public interface DeploymentService {
      * @throws DeploymentServiceException if there was an error while executing the deployments
      */
     Deployment deployTarget(String env, String siteName, boolean waitTillDone,
-                            Map<String, Object> params) throws TargetNotFoundException, DeploymentServiceException;
+                            Map<String, Object> params) throws TargetNotFoundException, DeploymentServiceException, TargetNotReadyException;
 
 }

--- a/src/main/java/org/craftercms/deployer/api/DeploymentService.java
+++ b/src/main/java/org/craftercms/deployer/api/DeploymentService.java
@@ -49,8 +49,9 @@ public interface DeploymentService {
      * @param params        additional parameters that can be used by the deployment processors
      *
      * @return the deployment info
-     *
+     * @throws TargetNotFoundException if the target for the specified env and site name was not found
      * @throws DeploymentServiceException if there was an error while executing the deployments
+     * @throws TargetNotReadyException if the target is not ready to accept deployments
      */
     Deployment deployTarget(String env, String siteName, boolean waitTillDone,
                             Map<String, Object> params) throws TargetNotFoundException, DeploymentServiceException, TargetNotReadyException;

--- a/src/main/java/org/craftercms/deployer/impl/DeploymentServiceImpl.java
+++ b/src/main/java/org/craftercms/deployer/impl/DeploymentServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2023 Crafter Software Corporation. All Rights Reserved.
+ * Copyright (C) 2007-2026 Crafter Software Corporation. All Rights Reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as published by
@@ -83,10 +83,10 @@ public class DeploymentServiceImpl implements DeploymentService {
     @Override
     public Deployment deployTarget(String env, String siteName, boolean waitTillDone,
                                    Map<String, Object> params) throws TargetNotFoundException,
-                                                                      DeploymentServiceException {
+			DeploymentServiceException, TargetNotReadyException {
         try {
             return targetService.getTarget(env, siteName).deploy(waitTillDone, params);
-        } catch (TargetServiceException | TargetNotReadyException e) {
+        } catch (TargetServiceException e) {
             throw new DeploymentServiceException(format("Error while deploying target '%s'", TargetImpl.getId(env, siteName)), e);
         }
     }

--- a/src/main/java/org/craftercms/deployer/impl/rest/ExceptionHandlers.java
+++ b/src/main/java/org/craftercms/deployer/impl/rest/ExceptionHandlers.java
@@ -23,6 +23,7 @@ import org.craftercms.commons.validation.rest.ValidationAwareRestExceptionHandle
 import org.craftercms.core.controller.rest.ValidationFieldError;
 import org.craftercms.deployer.api.exceptions.TargetAlreadyExistsException;
 import org.craftercms.deployer.api.exceptions.TargetNotFoundException;
+import org.craftercms.deployer.api.exceptions.TargetNotReadyException;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpHeaders;
@@ -92,6 +93,12 @@ public class ExceptionHandlers extends ValidationAwareRestExceptionHandlers {
     public ResponseEntity<Object> handleInvalidManagementTokenException(InvalidManagementTokenException ex,
                                                                         WebRequest request) {
         return handleExceptionInternal(ex, "Invalid management token", new HttpHeaders(), HttpStatus.UNAUTHORIZED,
+                request);
+    }
+
+    @ExceptionHandler(TargetNotReadyException.class)
+    public ResponseEntity<Object> handleTargetNotReadyException(TargetNotReadyException ex, WebRequest request) {
+        return handleExceptionInternal(ex, ex.getMessage(), new HttpHeaders(), HttpStatus.SERVICE_UNAVAILABLE,
                 request);
     }
 


### PR DESCRIPTION
Return 503 (instead of 500) when trying to deploy a target that is no ready
https://github.com/craftercms/craftercms/issues/8497
