### PR TITLE
Close opensearch instance on destroy

### DIFF
--- a/src/main/java/org/craftercms/deployer/utils/opensearch/AbstractOpenSearchFactory.java
+++ b/src/main/java/org/craftercms/deployer/utils/opensearch/AbstractOpenSearchFactory.java
@@ -17,14 +17,14 @@
 
 package org.craftercms.deployer.utils.opensearch;
 
+import java.util.ArrayList;
+
 import org.craftercms.commons.config.ConfigurationException;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.BeanNameAware;
 import org.springframework.beans.factory.config.AbstractFactoryBean;
-
-import java.util.ArrayList;
 
 /**
  * Base implementation for factories capable of build single or multi-cluster OpenSearch services
@@ -54,6 +54,14 @@ public abstract class AbstractOpenSearchFactory<T> extends AbstractFactoryBean<T
 	@Override
 	public void setBeanName(final String name) {
 		this.name = name;
+	}
+
+	@Override
+	protected void destroyInstance(T instance) throws Exception {
+		logger.debug("Closing OpenSearch service for '{}'", name);
+		if (instance instanceof AutoCloseable closeable) {
+			closeable.close();
+		}
 	}
 
 	@Override


### PR DESCRIPTION
Close opensearch instance on destroy
https://github.com/craftersoftware/craftercms/issues/1265

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource cleanup during application shutdown by closing supported OpenSearch-related resources automatically.
  * Added shutdown logging to help track resource destruction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->